### PR TITLE
deployment: add: manifest for requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
Hey,

I was trying to [add `gptcache` to conda-forge](https://github.com/conda-forge/staged-recipes/pull/22559) and realized that without a valid `requirements.txt` this does not work.
This `MANIFEST.in` file is the _shortest_ (not best way) to achieve that, since it tells python to include the file for an sdist distribution.

---
small explanation:
I think the initial problem is that using a `setup.py` changes things downstream.
I'm not 100% sure, but I've seen and built repos without a `requirements.txt` file at all and it seemed to work with just a `setup.cfg`. Happy to submit one, if you want.