### PR TITLE
Support pgvector as vector store.

### DIFF
--- a/.github/workflows/unit_test_main.yaml
+++ b/.github/workflows/unit_test_main.yaml
@@ -31,8 +31,11 @@ jobs:
     services:
       postgres:
         image: ankane/pgvector
+        ports:
+          - 5432:5432
         env:
           POSTGRES_PASSWORD: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@main
 

--- a/.github/workflows/unit_test_main.yaml
+++ b/.github/workflows/unit_test_main.yaml
@@ -28,6 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    services:
+      postgres:
+        image: ankane/pgvector
+        env:
+          POSTGRES_PASSWORD: postgres
     steps:
       - uses: actions/checkout@main
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ The **Vector Store** module helps find the K most similar requests from the inpu
   - [x] Support [Milvus Lite](https://github.com/milvus-io/milvus-lite), a lightweight version of Milvus that can be embedded into your Python application.
   - [x] Support [FAISS](https://faiss.ai/), a library for efficient similarity search and clustering of dense vectors.
   - [x] Support [Hnswlib](https://github.com/nmslib/hnswlib), header-only C++/python library for fast approximate nearest neighbors.
+  - [x] Support [pgvector](https://github.com/pgvector/pgvector), open-source vector similarity search for Postgres.
   - [ ] Support qdrant
   - [ ] Support weaviate
   - [ ] Support chroma

--- a/gptcache/manager/vector_data/__init__.py
+++ b/gptcache/manager/vector_data/__init__.py
@@ -13,6 +13,7 @@ def VectorBase(name: str, **kwargs):
        `Faiss` (with , `index_path`, `dimension`, `top_k` params),
        `Chromadb` (with `top_k`, `client_settings`, `persist_directory`, `collection_name` params),
        `Hnswlib` (with `index_file_path`, `dimension`, `top_k`, `max_elements` params).
+       `pgvector` (with `url`, `collection_name`, `index_params`, `top_k`, `dimension` params).
 
     :param name: the name of the vectorbase, it is support 'milvus', 'faiss', 'chromadb', 'hnswlib' now.
     :type name: str
@@ -47,6 +48,13 @@ def VectorBase(name: str, **kwargs):
     :type local_mode: bool
     :param local_data: required when local_mode is True.
     :type local_data: str
+
+    :param url: the host for PostgreSQL vector database, defaults to 'localhost'.
+    :type url: str
+    :param index_params: the index parameters for pgvector.
+    :type index_params: dict
+    :param collection_name: the prefix of the table for PostgreSQL pgvector, defaults to 'gptcache'.
+    :type collection_name: str
 
     :param client_settings: the setting for Chromadb.
     :type client_settings: Settings

--- a/gptcache/manager/vector_data/__init__.py
+++ b/gptcache/manager/vector_data/__init__.py
@@ -49,7 +49,7 @@ def VectorBase(name: str, **kwargs):
     :param local_data: required when local_mode is True.
     :type local_data: str
 
-    :param url: the host for PostgreSQL vector database, defaults to 'localhost'.
+    :param url: the connection url for PostgreSQL database, defaults to 'postgresql://postgres@localhost:5432/postgres'
     :type url: str
     :param index_params: the index parameters for pgvector.
     :type index_params: dict

--- a/gptcache/manager/vector_data/manager.py
+++ b/gptcache/manager/vector_data/manager.py
@@ -16,6 +16,13 @@ MILVUS_INDEX_PARAMS = {
     "params": {"M": 8, "efConstruction": 64},
 }
 
+PGVECTOR_URL="postgresql://postgres:postgres@localhost:5432/postgres"
+PGVECTOR_INDEX_PARAMS = {
+    "index_type": "L2",
+    "params": {"lists": 100, "probes": 10}
+}
+
+
 COLLECTION_NAME = "gptcache"
 
 
@@ -100,6 +107,19 @@ class VectorBase:
             vector_base = Hnswlib(
                 index_file_path=index_path, dimension=dimension,
                 top_k=top_k, max_elements=max_elements
+            )
+        elif name == "pgvector":
+            from gptcache.manager.vector_data.pgvector import PGVector
+            dimension = kwargs.get("dimension", DIMENSION)
+            url = kwargs.get("url", PGVECTOR_URL)
+            collection_name = kwargs.get("collection_name", COLLECTION_NAME)
+            index_params = kwargs.get("index_params", PGVECTOR_INDEX_PARAMS)
+            vector_base = PGVector(
+                dimension = dimension,
+                top_k = top_k,
+                url = url,
+                collection_name = collection_name,
+                index_params = index_params
             )
         else:
             raise NotFoundError("vector store", name)

--- a/gptcache/manager/vector_data/pgvector.py
+++ b/gptcache/manager/vector_data/pgvector.py
@@ -1,0 +1,173 @@
+from typing import List
+import numpy as np
+
+from gptcache.manager.vector_data.base import VectorBase, VectorData
+from gptcache.utils import import_sqlalchemy
+
+import_sqlalchemy()
+
+# pylint: disable=wrong-import-position
+from sqlalchemy import create_engine, Column, Index, text  # pylint: disable=C0413
+from sqlalchemy.types import (  # pylint: disable=C0413
+    Integer,
+    UserDefinedType
+)
+from sqlalchemy.orm import sessionmaker  # pylint: disable=C0413
+from sqlalchemy.ext.declarative import declarative_base  # pylint: disable=C0413
+
+Base = declarative_base()
+
+class VectorType(UserDefinedType):
+    """
+    pgvector type mapping for sqlalchemy
+    """
+    cache_ok = True
+
+    def __init__(self, precision = 8):
+        self.precision = precision
+
+    def get_col_spec(self, **_):
+        return f"vector({self.precision})"
+
+    def bind_processor(self, dialect):
+        def process(value):
+            return value
+        return process
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            return value
+        return process
+
+def get_model_and_index(table_prefix, vector_dimension, index_type, lists):
+    class VectorStoreTable(Base):
+        """
+        vector store table
+        """
+
+        __tablename__ = table_prefix + "_vector_store"
+        __table_args__ = {"extend_existing": True}
+        id = Column(Integer, primary_key=True, autoincrement=False)
+        embedding = Column(VectorType(vector_dimension), nullable=False)
+
+    vector_store_index = Index(
+        f"idx_{table_prefix}_vector_store_embedding",
+        text(f"embedding {index_type}"),
+        postgresql_using="ivfflat",
+        postgresql_with={"lists": lists}
+    )
+
+    vector_store_index.table = VectorStoreTable.__table__
+
+    return VectorStoreTable, vector_store_index
+
+
+
+class PGVector(VectorBase):
+    """vector store: pgvector
+
+    :param url: the url for PostgreSQL database, defaults to 'postgresql://postgres@localhost:5432/postgres'.
+    :type url: str
+    :type collection_name: str
+    :param dimension: the dimension of the vector, defaults to 0.
+    :type dimension: int
+    :param top_k: the umber of the vectors results to return, defaults to 1.
+    :type top_k: int
+    :param index_params: the index parameters for pgvector, defaults to the HNSW index: {'metric_type': 'L2', 'index_type': 'HNSW', 'params': {'M':
+                         8, 'efConstruction': 64}}.
+    :type index_params: dict
+    """
+
+    INDEX_PARAM = {
+        "L2": { "operator": "<->", "name": "vector_l2_ops" }, # The only one supported now
+        "cosine": { "operator": "<=>", "name": "vector_cosine_ops" },
+        "inner_product": { "operator": "<->", "name": "vector_ip_ops" },
+    }
+
+
+    def __init__(
+        self,
+        url: str,
+        index_params: dict,
+        collection_name: str = "gptcache",
+        dimension: int = 0,
+        top_k: int = 1,
+    ):
+        if dimension <= 0:
+            raise ValueError(
+                f"invalid `dim` param: {dimension} in the pgvector store."
+            )
+        self.dimension = dimension
+        self.top_k = top_k
+        self.index_params = index_params
+        self._url = url
+        self._store, self._index = get_model_and_index(
+            collection_name,
+            dimension,
+            index_type = self.INDEX_PARAM[index_params["index_type"]]["name"],
+            lists = index_params["params"]["lists"]
+        )
+        self._connect(url)
+        self._create_collection()
+
+    def _connect(self, url):
+        self._engine = create_engine(url, echo=False)
+        self._session = sessionmaker(bind=self._engine)  # pylint: disable=invalid-name
+
+    def _create_collection(self):
+        with self._engine.connect() as con:
+            con.execution_options(isolation_level="AUTOCOMMIT").execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+
+        self._store.__table__.create(bind=self._engine, checkfirst=True)
+        self._index.create(bind=self._engine, checkfirst=True)
+
+    def _query(self, session):
+        return session.query(self._store)
+
+    def _format_data_for_search(self, data):
+        return f"[{','.join(map(str, data))}]"
+
+    def mul_add(self, datas: List[VectorData]):
+        data_array, id_array = map(list, zip(*((data.data, data.id) for data in datas)))
+        np_data = np.array(data_array).astype("float32")
+        entities = [{"id": id, "embedding": embedding.tolist()} for id, embedding in zip(id_array, np_data)]
+
+        with self._session() as session:
+            session.bulk_insert_mappings(self._store, entities)
+            session.commit()
+
+    def search(self, data: np.ndarray, top_k: int = -1):
+        if top_k == -1:
+            top_k = self.top_k
+
+        formatted_data = self._format_data_for_search(data.reshape(1, -1)[0].tolist())
+        index_config = self.INDEX_PARAM[self.index_params["index_type"]]
+        similarity = self._store.embedding.op(index_config["operator"])(formatted_data)
+        with self._session() as session:
+            session.execute(text(f"SET LOCAL ivfflat.probes = {self.index_params['params']['probes'] or 10};"))
+            search_result = self._query(session).add_columns(
+                similarity.label("distances")
+            ).order_by(
+                similarity
+            ).limit(top_k).all()
+
+        return search_result
+
+    def delete(self, ids = None):
+        with self._session() as session:
+            if ids is None:
+                self._query(session).delete()
+            else:
+                self._query(session).filter(self._store.id.in_(ids)).delete()
+            session.commit()
+
+    def rebuild(self, ids=None):  # pylint: disable=unused-argument
+        with self._engine.connect() as con:
+            con.execution_options(isolation_level="AUTOCOMMIT").execute(text(f"REINDEX INDEX CONCURRENTLY {self._index.name}"))
+
+    def flush(self):
+        with self._session() as session:
+            session.flush()
+
+    def close(self):
+        self.flush()

--- a/gptcache/manager/vector_data/pgvector.py
+++ b/gptcache/manager/vector_data/pgvector.py
@@ -73,8 +73,8 @@ class PGVector(VectorBase):
     :type dimension: int
     :param top_k: the umber of the vectors results to return, defaults to 1.
     :type top_k: int
-    :param index_params: the index parameters for pgvector, defaults to the HNSW index: {'metric_type': 'L2', 'index_type': 'HNSW', 'params': {'M':
-                         8, 'efConstruction': 64}}.
+    :param index_params: the index parameters for pgvector, defaults to 'vector_l2_ops' index:
+                         {"index_type": "L2", "params": {"lists": 100, "probes": 10}.
     :type index_params: dict
     """
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,6 +14,7 @@ git+https://github.com/Projectplace/pytest-tags
 pytest-html==3.1.1
 pytest-sugar==0.9.5
 pytest-parallel
+psycopg2
 torch
 mock
 pexpect

--- a/tests/unit_tests/manager/test_pgvector.py
+++ b/tests/unit_tests/manager/test_pgvector.py
@@ -12,7 +12,7 @@ class TestPgvector(unittest.TestCase):
         dim = 512
         top_k = 10
 
-        url = os.getenv("POSTGRES_URL", "postgresql://postgres:postgres@postgres:5432/postgres")
+        url = os.getenv("POSTGRES_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
 
         db = VectorBase(
             "pgvector",

--- a/tests/unit_tests/manager/test_pgvector.py
+++ b/tests/unit_tests/manager/test_pgvector.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+import numpy as np
+
+from gptcache.manager.vector_data import VectorBase
+from gptcache.manager.vector_data.base import VectorData
+
+
+class TestPgvector(unittest.TestCase):
+    def test_normal(self):
+        size = 1000
+        dim = 512
+        top_k = 10
+
+        url = os.getenv("POSTGRES_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
+
+        db = VectorBase(
+            "pgvector",
+            top_k=top_k,
+            dimension=dim,
+            url=url,
+            index_params={
+                "index_type": "L2",
+                "params": {"lists": 100, "probes": 10},
+            },
+        )
+        db.delete()
+        data = np.random.randn(size, dim).astype(np.float32)
+        db.mul_add([VectorData(id=i, data=v) for v, i in zip(data, range(size))])
+        self.assertEqual(len(db.search(data[0])), top_k)
+        db.mul_add([VectorData(id=size, data=data[0])])
+        ret = db.search(data[0])
+        self.assertIn(ret[0][1], [0, size])
+        self.assertIn(ret[1][1], [0, size])
+        db.delete([0, 1, 2, 3, 4, 5, size])
+        ret = db.search(data[0])
+        self.assertNotIn(ret[0][1], [0, size])
+        db.rebuild()
+        db.close()

--- a/tests/unit_tests/manager/test_pgvector.py
+++ b/tests/unit_tests/manager/test_pgvector.py
@@ -12,7 +12,7 @@ class TestPgvector(unittest.TestCase):
         dim = 512
         top_k = 10
 
-        url = os.getenv("POSTGRES_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
+        url = os.getenv("POSTGRES_URL", "postgresql://postgres:postgres@postgres:5432/postgres")
 
         db = VectorBase(
             "pgvector",
@@ -24,7 +24,7 @@ class TestPgvector(unittest.TestCase):
                 "params": {"lists": 100, "probes": 10},
             },
         )
-        db.delete()
+        db.delete([i for i in range(size)])
         data = np.random.randn(size, dim).astype(np.float32)
         db.mul_add([VectorData(id=i, data=v) for v, i in zip(data, range(size))])
         self.assertEqual(len(db.search(data[0])), top_k)


### PR DESCRIPTION
I've tried to implement #332 (aka support for pgvector as a vector store).

It's largely based on the Milvus' one.

It uses by default a `vector_l2_ops` index with `lists = 100` and `probes = 10`.
Not sure if it's the optimal setup for GPTCache.

I've implemented the same tests and added a PostgreSQL service to Github Actions using the [official pgvector docker image](https://hub.docker.com/r/ankane/pgvector), so it can be tested on CI.

My knowledge of both system is not super deep, so I'm super-open to feedback and suggestions on how to improve this.

Thanks!