### PR TITLE
[Feature] search only operation support

### DIFF
--- a/gptcache/adapter/adapter.py
+++ b/gptcache/adapter/adapter.py
@@ -15,6 +15,7 @@ def adapt(llm_handler, cache_data_convert, update_cache_callback, *args, **kwarg
     :param kwargs: llm kwargs
     :return: llm result
     """
+    search_only_flag = kwargs.pop("search_only", False)
     user_temperature = "temperature" in kwargs
     user_top_k = "top_k" in kwargs
     temperature = kwargs.pop("temperature", 0.0)
@@ -191,6 +192,9 @@ def adapt(llm_handler, cache_data_convert, update_cache_callback, *args, **kwarg
             llm_handler, cache_data_convert, update_cache_callback, *args, **kwargs
         )
     else:
+        if search_only_flag:
+            # cache miss
+            return None
         llm_data = time_cal(
             llm_handler, func_name="llm_request", report_func=chat_cache.report.llm
         )(*args, **kwargs)


### PR DESCRIPTION
What is it: adds a switch to configure GPTCache in search only mode, i.e. if cache misses, return None directly without calling LLM API.

Motivation: In certain application, we want to have full control on what to cache and when to update the cache, therefore whenever a cache miss happens, we don't want to call LLM API directly because the query used in cache search may be totally different to the query used in actual LLM call. if cache misses, we just want the code return with None so we know cache missd. 