### PR TITLE
[Feature] Cache consistency check for Chroma & Milvus

### DIFF
--- a/gptcache/adapter/adapter.py
+++ b/gptcache/adapter/adapter.py
@@ -15,6 +15,7 @@ def adapt(llm_handler, cache_data_convert, update_cache_callback, *args, **kwarg
     :param kwargs: llm kwargs
     :return: llm result
     """
+    search_only_flag = kwargs.pop("search_only", False)
     user_temperature = "temperature" in kwargs
     user_top_k = "top_k" in kwargs
     temperature = kwargs.pop("temperature", 0.0)
@@ -191,6 +192,9 @@ def adapt(llm_handler, cache_data_convert, update_cache_callback, *args, **kwarg
             llm_handler, cache_data_convert, update_cache_callback, *args, **kwargs
         )
     else:
+        if search_only_flag:
+            # cache miss
+            return None
         llm_data = time_cal(
             llm_handler, func_name="llm_request", report_func=chat_cache.report.llm
         )(*args, **kwargs)

--- a/gptcache/adapter/adapter.py
+++ b/gptcache/adapter/adapter.py
@@ -512,7 +512,7 @@ def cache_health_check(vectordb, cache_dict):
         # from cache store by the same
         # entry_id.
         vectordb.update_embeddings(
-            id=data_id,
+            data_id,
             emb=cache_dict["embedding"],
         )
     return flag

--- a/gptcache/adapter/adapter.py
+++ b/gptcache/adapter/adapter.py
@@ -1,3 +1,4 @@
+import numpy as np
 from gptcache import cache
 from gptcache.processor.post import temperature_softmax
 from gptcache.utils.error import NotInitError
@@ -15,6 +16,7 @@ def adapt(llm_handler, cache_data_convert, update_cache_callback, *args, **kwarg
     :param kwargs: llm kwargs
     :return: llm result
     """
+    health_check_flag = kwargs.pop("health_check", False)
     search_only_flag = kwargs.pop("search_only", False)
     user_temperature = "temperature" in kwargs
     user_top_k = "top_k" in kwargs
@@ -110,6 +112,18 @@ def adapt(llm_handler, cache_data_convert, update_cache_callback, *args, **kwarg
             )
             if cache_data is None:
                 continue
+
+            # cache consistency check
+            if health_check_flag:
+                is_healthy = cache_health_check(
+                    chat_cache.data_manager.v,
+                    {
+                        "embedding": cache_data.embedding_data,
+                        "search_result": search_data,
+                    }
+                )
+                if not is_healthy:
+                    continue
 
             if "deps" in context and hasattr(cache_data.question, "deps"):
                 eval_query_data = {
@@ -469,3 +483,32 @@ def _summarize_input(text, text_length):
     summarization = _input_summarizer.summarize_to_sentence([text], text_length)
     return summarization
 
+def cache_health_check(vectordb, cache_dict):
+    """This function checks if the embedding
+        from vector store matches one in cache store.
+        If cache store and vector store are out of
+        sync with each other, cache retrieval can
+        be incorrect.
+        If this happens, force the similary score
+        to the lowerest possible value.
+    """
+    emb_in_cache = cache_dict["embedding"]
+    _, data_id = cache_dict["search_result"]
+    emb_in_vec = vectordb.get_embeddings(data_id)
+    flag = np.all(emb_in_cache == emb_in_vec)
+    if not flag:
+        gptcache_log.critical("Cache Store and Vector Store are out of sync!!!")
+        # 0: identical, inf: different
+        cache_dict["search_result"] = (
+            np.inf,
+            data_id,
+        )
+        # self-healing by replacing entry
+        # in the vec store with the one
+        # from cache store by the same
+        # entry_id.
+        vectordb.update_embeddings(
+            id=data_id,
+            emb=cache_dict["embedding"],
+        )
+    return flag

--- a/gptcache/manager/vector_data/base.py
+++ b/gptcache/manager/vector_data/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -34,4 +34,10 @@ class VectorBase(ABC):
         pass
 
     def close(self):
+        pass
+
+    def get_embeddings(self, id: Union[int, str]) -> Optional[np.ndarray]:
+        raise NotImplementedError
+
+    def update_embeddings(self, id: Union[int, str], emb: np.ndarray):
         pass

--- a/gptcache/manager/vector_data/base.py
+++ b/gptcache/manager/vector_data/base.py
@@ -36,8 +36,8 @@ class VectorBase(ABC):
     def close(self):
         pass
 
-    def get_embeddings(self, id: Union[int, str]) -> Optional[np.ndarray]:
+    def get_embeddings(self, data_id: Union[int, str]) -> Optional[np.ndarray]:
         raise NotImplementedError
 
-    def update_embeddings(self, id: Union[int, str], emb: np.ndarray):
+    def update_embeddings(self, data_id: Union[int, str], emb: np.ndarray):
         pass

--- a/gptcache/manager/vector_data/chroma.py
+++ b/gptcache/manager/vector_data/chroma.py
@@ -1,5 +1,5 @@
-from typing import List
-
+from typing import List, Optional, Union
+import numpy as np
 from gptcache.manager.vector_data.base import VectorBase, VectorData
 from gptcache.utils import import_chromadb, import_torch
 
@@ -65,3 +65,19 @@ class Chromadb(VectorBase):
 
     def rebuild(self, ids=None):  # pylint: disable=unused-argument
         return True
+
+    def get_embeddings(self, id: str):
+        vec_emb = self._collection.get(
+                id, 
+                include=['embeddings'],
+            )['embeddings']
+        if vec_emb is None or len(vec_emb) < 1:
+            return None
+        vec_emb = np.asarray(vec_emb[0], dtype="float32")
+        return vec_emb
+
+    def update_embeddings(self, id: str, emb: np.ndarray):
+        self._collection.update(
+            ids=id,
+            embeddings=emb.tolist(),
+        )

--- a/gptcache/manager/vector_data/chroma.py
+++ b/gptcache/manager/vector_data/chroma.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List
 import numpy as np
 from gptcache.manager.vector_data.base import VectorBase, VectorData
 from gptcache.utils import import_chromadb, import_torch
@@ -66,18 +66,18 @@ class Chromadb(VectorBase):
     def rebuild(self, ids=None):  # pylint: disable=unused-argument
         return True
 
-    def get_embeddings(self, id: str):
+    def get_embeddings(self, data_id: str):
         vec_emb = self._collection.get(
-                id, 
-                include=['embeddings'],
-            )['embeddings']
+                data_id,
+                include=["embeddings"],
+            )["embeddings"]
         if vec_emb is None or len(vec_emb) < 1:
             return None
         vec_emb = np.asarray(vec_emb[0], dtype="float32")
         return vec_emb
 
-    def update_embeddings(self, id: str, emb: np.ndarray):
+    def update_embeddings(self, data_id: str, emb: np.ndarray):
         self._collection.update(
-            ids=id,
+            ids=data_id,
             embeddings=emb.tolist(),
         )

--- a/gptcache/manager/vector_data/milvus.py
+++ b/gptcache/manager/vector_data/milvus.py
@@ -194,3 +194,21 @@ class Milvus(VectorBase):
         self.flush()
         if self._local_mode:
             self._server.stop()
+
+    def get_embeddings(self, id: int):
+        vec_emb = self.col.query(
+            expr=f"id == {id}",
+            output_fields=["embedding"],
+        )
+        if len(vec_emb) < 1:
+            return None
+        vec_emb = np.asarray(vec_emb[0]["embedding"], dtype="float32")
+        return vec_emb
+
+    def update_embeddings(self, id: int, emb: np.ndarray):
+        self.col.delete(f"id in [{id}]")
+        data = [
+            [id],
+            np.expand_dims(emb, axis=0),
+        ]
+        self.col.insert(data)

--- a/gptcache/manager/vector_data/milvus.py
+++ b/gptcache/manager/vector_data/milvus.py
@@ -195,9 +195,9 @@ class Milvus(VectorBase):
         if self._local_mode:
             self._server.stop()
 
-    def get_embeddings(self, id: int):
+    def get_embeddings(self, data_id: int):
         vec_emb = self.col.query(
-            expr=f"id == {id}",
+            expr=f"id == {data_id}",
             output_fields=["embedding"],
         )
         if len(vec_emb) < 1:
@@ -205,10 +205,10 @@ class Milvus(VectorBase):
         vec_emb = np.asarray(vec_emb[0]["embedding"], dtype="float32")
         return vec_emb
 
-    def update_embeddings(self, id: int, emb: np.ndarray):
-        self.col.delete(f"id in [{id}]")
+    def update_embeddings(self, data_id: int, emb: np.ndarray):
+        self.col.delete(f"id in [{data_id}]")
         data = [
-            [id],
+            [data_id],
             np.expand_dims(emb, axis=0),
         ]
         self.col.insert(data)

--- a/gptcache/similarity_evaluation/distance.py
+++ b/gptcache/similarity_evaluation/distance.py
@@ -1,6 +1,8 @@
 from typing import Tuple, Dict, Any
-
+import numpy as np
 from gptcache.similarity_evaluation import SimilarityEvaluation
+from gptcache.manager.vector_data.base import VectorBase
+from gptcache.utils.log import gptcache_log
 
 
 class SearchDistanceEvaluation(SimilarityEvaluation):
@@ -31,9 +33,11 @@ class SearchDistanceEvaluation(SimilarityEvaluation):
             )
     """
 
-    def __init__(self, max_distance=4.0, positive=False):
+    def __init__(self, max_distance=4.0, positive=False, vectordb: VectorBase = None, cache_check: bool = False):
         self.max_distance = max_distance
         self.positive = positive
+        self.vectordb = vectordb
+        self.cache_check = cache_check
 
     def evaluation(
         self, src_dict: Dict[str, Any], cache_dict: Dict[str, Any], **_
@@ -46,6 +50,7 @@ class SearchDistanceEvaluation(SimilarityEvaluation):
 
         :return: evaluation score.
         """
+        self.cache_health_check(cache_dict)
         distance, _ = cache_dict["search_result"]
         if distance < 0:
             distance = 0
@@ -61,3 +66,33 @@ class SearchDistanceEvaluation(SimilarityEvaluation):
         :return: minimum and maximum of similarity score.
         """
         return 0.0, self.max_distance
+
+    def cache_health_check(self, cache_dict: Dict[str, Any]):
+        """This function checks if the embedding
+           from vector store matches one in cache store.
+           If cache store and vector store are out of
+           sync with each other, cache retrieval can
+           be incorrect.
+           If this happens, force the similary score
+           to the lowerest possible value.
+        """
+        if self.cache_check:
+            emb_in_cache = cache_dict["embedding"]
+            _, data_id = cache_dict["search_result"]
+            emb_in_vec = self.vectordb.get_embeddings(data_id)
+            flag = np.all(emb_in_cache == emb_in_vec)
+            if not flag:
+                gptcache_log.critical("Cache Store and Vector Store are out of sync!!!")
+                # 0: identical, inf: different
+                cache_dict["search_result"] = (
+                    np.inf,
+                    data_id,
+                )
+                # self-healing by replacing entry
+                # in the vec store with the one
+                # from cache store by the same
+                # entry_id.
+                self.vectordb.update_embeddings(
+                    id=data_id,
+                    emb=cache_dict["embedding"],
+                )

--- a/gptcache/similarity_evaluation/distance.py
+++ b/gptcache/similarity_evaluation/distance.py
@@ -1,5 +1,4 @@
 from typing import Tuple, Dict, Any
-import numpy as np
 from gptcache.similarity_evaluation import SimilarityEvaluation
 
 

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -47,6 +47,7 @@ class TestSqliteMilvus(Base):
                 "milvus",
                 dimension=onnx.dimension,
                 local_mode=True,
+                port="10086",
                 local_data=str(root),
             )
             data_manager = get_data_manager("sqlite", vector_base, max_size=2000)
@@ -135,5 +136,3 @@ class TestSqliteMilvus(Base):
                 stream=True,
             )
             assert get_text_response(response) == answer[0]
-            vector_base.rebuild()
-            vector_base.close()

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -1,0 +1,189 @@
+import os
+import shutil
+import pytest
+
+from base.client_base import Base
+from common import common_func as cf
+from gptcache import cache, Config
+from gptcache.adapter import openai
+from gptcache.embedding import Onnx, SBERT
+from gptcache.manager import get_data_manager, VectorBase
+from gptcache.similarity_evaluation.distance import SearchDistanceEvaluation
+from utils.util_log import test_log as log
+
+
+def get_text_response(response):
+    if response is None:
+        return ""
+    collated_response = [
+        chunk["choices"][0]["delta"].get("content", "")
+        for chunk in response
+    ]
+    return "".join(collated_response)
+
+
+class TestSqliteMilvus(Base):
+
+    """
+    ******************************************************************
+    #  The followings are general cases
+    ******************************************************************
+    """
+
+    @pytest.mark.tags("L1")
+    def test_hit_cache_out_of_sync(self):
+        """
+        target: test hit the cache function
+        method: keep default similarity_threshold
+        expected: hit successfully but return wrong reponse to user
+        """
+        if os.path.isfile("./sqlite.db"):
+            os.remove("./sqlite.db")
+        if os.path.isdir('./milvus_data'):
+            shutil.rmtree('./milvus_data')
+
+        onnx = SBERT("/home/bryan/Projects/Github/PayPal/ModelZoo/transformers/all-MiniLM-L6-v2")
+        vector_base = VectorBase("milvus", dimension=onnx.dimension, local_mode=True)
+        data_manager = get_data_manager("sqlite", vector_base, max_size=2000)
+        cache.init(
+            embedding_func=onnx.to_embeddings,
+            data_manager=data_manager,
+            similarity_evaluation=SearchDistanceEvaluation(),
+            config=Config(
+                log_time_func=cf.log_time_func,
+                enable_token_counter=False,
+            ),
+        )
+
+        question = [
+            "what is apple?",
+            "what is intel?",
+            "what is openai?",
+
+        ]
+        answer = [
+            "apple",
+            "intel",
+            "openai"
+        ]
+        for q, a in zip(question, answer):
+            cache.data_manager.save(q, a, cache.embedding_func(q))
+
+        # let's simulate cache out-of-sync
+        # situation.
+        touble_query = "what is google?"
+        cache.data_manager.v.update_embeddings(1, cache.embedding_func(touble_query))
+
+        is_exception = False
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": touble_query},
+            ],
+            search_only=True,
+            stream=True,
+        )
+        try:
+            assert answer[1] == get_text_response(response), "Incorrect response returned to user..."
+        except Exception as e:
+            log.info(e)
+            is_exception = True
+        
+        assert is_exception
+
+    @pytest.mark.tags("L1")
+    def test_cache_health_check(self):
+        """
+        target: test hit the cache function
+        method: keep default similarity_threshold
+        expected: hit successfully but return wrong reponse to user
+        """
+        if os.path.isfile("./sqlite.db"):
+            os.remove("./sqlite.db")
+        if os.path.isdir('./milvus_data'):
+            shutil.rmtree('./milvus_data')
+
+        onnx = SBERT("/home/bryan/Projects/Github/PayPal/ModelZoo/transformers/all-MiniLM-L6-v2")
+        vector_base = VectorBase("milvus", dimension=onnx.dimension, local_mode=True)
+        data_manager = get_data_manager("sqlite", vector_base, max_size=2000)
+        cache.init(
+            embedding_func=onnx.to_embeddings,
+            data_manager=data_manager,
+            similarity_evaluation=SearchDistanceEvaluation(
+                vectordb=vector_base,
+                cache_check=True,
+            ),
+            config=Config(
+                log_time_func=cf.log_time_func,
+                enable_token_counter=False,
+            ),
+        )
+
+        question = [
+            "what is apple?",
+            "what is intel?",
+            "what is openai?",
+
+        ]
+        answer = [
+            "apple",
+            "intel",
+            "openai"
+        ]
+        for q, a in zip(question, answer):
+            cache.data_manager.save(q, a, cache.embedding_func(q))
+
+        # let's simulate cache out-of-sync
+        # situation.
+        touble_query = "what is google?"
+        cache.data_manager.v.update_embeddings(1, cache.embedding_func(touble_query))
+
+        # cache health enabled
+        # stop returning incorrect answer
+        # and self-heal the trouble cache
+        # entry.
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": touble_query},
+            ],
+            search_only=True,
+            stream=True,
+        )
+        assert response is None
+        
+        # disable cache check, and verify
+        # cache is now consistent
+        cache.similarity_evaluation.cache_check = False
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": touble_query},
+            ],
+            search_only=True,
+            stream=True,
+        )
+        assert response is None
+
+        # verify self-heal took place
+        cache.similarity_evaluation.cache_check = False
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": question[0]},
+            ],
+            search_only=True,
+            stream=True,
+        )
+        assert get_text_response(response) == answer[0]
+
+       
+
+
+
+a = TestSqliteMilvus()
+a.test_cache_health_check()

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -107,10 +107,7 @@ class TestSqliteMilvus(Base):
         cache.init(
             embedding_func=onnx.to_embeddings,
             data_manager=data_manager,
-            similarity_evaluation=SearchDistanceEvaluation(
-                vectordb=vector_base,
-                cache_check=True,
-            ),
+            similarity_evaluation=SearchDistanceEvaluation(),
             config=Config(
                 log_time_func=cf.log_time_func,
                 enable_token_counter=False,
@@ -147,13 +144,13 @@ class TestSqliteMilvus(Base):
                 {"role": "user", "content": touble_query},
             ],
             search_only=True,
+            health_check=True,
             stream=True,
         )
         assert response is None
         
         # disable cache check, and verify
         # cache is now consistent
-        cache.similarity_evaluation.cache_check = False
         response = openai.ChatCompletion.create(
             model="gpt-3.5-turbo",
             messages=[
@@ -166,7 +163,6 @@ class TestSqliteMilvus(Base):
         assert response is None
 
         # verify self-heal took place
-        cache.similarity_evaluation.cache_check = False
         response = openai.ChatCompletion.create(
             model="gpt-3.5-turbo",
             messages=[

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -42,7 +42,7 @@ class TestSqliteMilvus(Base):
         if os.path.isdir('./milvus_data'):
             shutil.rmtree('./milvus_data')
 
-        onnx = SBERT("/home/bryan/Projects/Github/PayPal/ModelZoo/transformers/all-MiniLM-L6-v2")
+        onnx = SBERT()
         vector_base = VectorBase("milvus", dimension=onnx.dimension, local_mode=True)
         data_manager = get_data_manager("sqlite", vector_base, max_size=2000)
         cache.init(
@@ -104,7 +104,7 @@ class TestSqliteMilvus(Base):
         if os.path.isdir('./milvus_data'):
             shutil.rmtree('./milvus_data')
 
-        onnx = SBERT("/home/bryan/Projects/Github/PayPal/ModelZoo/transformers/all-MiniLM-L6-v2")
+        onnx = SBERT()
         vector_base = VectorBase("milvus", dimension=onnx.dimension, local_mode=True)
         data_manager = get_data_manager("sqlite", vector_base, max_size=2000)
         cache.init(
@@ -180,10 +180,3 @@ class TestSqliteMilvus(Base):
             stream=True,
         )
         assert get_text_response(response) == answer[0]
-
-       
-
-
-
-a = TestSqliteMilvus()
-a.test_cache_health_check()

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import pytest
-
+from tempfile import TemporaryDirectory
 from base.client_base import Base
 from common import common_func as cf
 from gptcache import cache, Config
@@ -36,96 +36,104 @@ class TestSqliteMilvus(Base):
         method: keep default similarity_threshold
         expected: cache health detection & correction
         """
-        if os.path.isfile("./sqlite.db"):
-            os.remove("./sqlite.db")
-        if os.path.isdir('./milvus_data'):
-            shutil.rmtree('./milvus_data')
+        with TemporaryDirectory(dir="./") as root:
+            if os.path.isfile("./sqlite.db"):
+                os.remove("./sqlite.db")
+            if os.path.isdir('./milvus_data'):
+                shutil.rmtree('./milvus_data')
 
-        onnx = SBERT()
-        vector_base = VectorBase("milvus", dimension=onnx.dimension, local_mode=True)
-        data_manager = get_data_manager("sqlite", vector_base, max_size=2000)
-        cache.init(
-            embedding_func=onnx.to_embeddings,
-            data_manager=data_manager,
-            similarity_evaluation=SearchDistanceEvaluation(),
-            config=Config(
-                log_time_func=cf.log_time_func,
-                enable_token_counter=False,
-            ),
-        )
+            onnx = SBERT()
+            vector_base = VectorBase(
+                "milvus",
+                dimension=onnx.dimension,
+                local_mode=True,
+                local_data=str(root),
+            )
+            data_manager = get_data_manager("sqlite", vector_base, max_size=2000)
+            cache.init(
+                embedding_func=onnx.to_embeddings,
+                data_manager=data_manager,
+                similarity_evaluation=SearchDistanceEvaluation(),
+                config=Config(
+                    log_time_func=cf.log_time_func,
+                    enable_token_counter=False,
+                ),
+            )
 
-        question = [
-            "what is apple?",
-            "what is intel?",
-            "what is openai?",
+            question = [
+                "what is apple?",
+                "what is intel?",
+                "what is openai?",
 
-        ]
-        answer = [
-            "apple",
-            "intel",
-            "openai"
-        ]
-        for q, a in zip(question, answer):
-            cache.data_manager.save(q, a, cache.embedding_func(q))
+            ]
+            answer = [
+                "apple",
+                "intel",
+                "openai"
+            ]
+            for q, a in zip(question, answer):
+                cache.data_manager.save(q, a, cache.embedding_func(q))
 
-        # let's simulate cache out-of-sync
-        # situation.
-        touble_query = "what is google?"
-        cache.data_manager.v.update_embeddings(1, cache.embedding_func(touble_query))
+            # let's simulate cache out-of-sync
+            # situation.
+            touble_query = "what is google?"
+            cache.data_manager.v.update_embeddings(1, cache.embedding_func(touble_query))
 
-        # without cache health check
-        # respons is incorrect
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": touble_query},
-            ],
-            search_only=True,
-            stream=True,
-        )
-        # Incorrect response "apple" returned to user
-        resp_txt = get_text_response(response)
-        # log.info(f"Inccorect response = {resp_txt} is returned")
-        assert answer[0] == resp_txt
+            # without cache health check
+            # respons is incorrect
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": touble_query},
+                ],
+                search_only=True,
+                stream=True,
+            )
+            # Incorrect response "apple" returned to user
+            resp_txt = get_text_response(response)
+            # log.info(f"Inccorect response = {resp_txt} is returned")
+            assert answer[0] == resp_txt
 
-        # cache health enabled
-        # stop returning incorrect answer
-        # and self-heal the trouble cache
-        # entry.
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": touble_query},
-            ],
-            search_only=True,
-            health_check=True,
-            stream=True,
-        )
-        assert response is None
-        
-        # disable cache check, and verify
-        # cache is now consistent
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": touble_query},
-            ],
-            search_only=True,
-            stream=True,
-        )
-        assert response is None
+            # cache health enabled
+            # stop returning incorrect answer
+            # and self-heal the trouble cache
+            # entry.
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": touble_query},
+                ],
+                search_only=True,
+                health_check=True,
+                stream=True,
+            )
+            assert response is None
+            
+            # disable cache check, and verify
+            # cache is now consistent
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": touble_query},
+                ],
+                search_only=True,
+                stream=True,
+            )
+            assert response is None
 
-        # verify self-heal took place
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": question[0]},
-            ],
-            search_only=True,
-            stream=True,
-        )
-        assert get_text_response(response) == answer[0]
+            # verify self-heal took place
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": question[0]},
+                ],
+                search_only=True,
+                stream=True,
+            )
+            assert get_text_response(response) == answer[0]
+            vector_base.rebuild()
+            vector_base.close()

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -84,13 +84,10 @@ class TestSqliteMilvus(Base):
             search_only=True,
             stream=True,
         )
-        try:
-            assert answer[1] == get_text_response(response), "Incorrect response returned to user..."
-        except Exception as e:
-            log.info(e)
-            is_exception = True
-        
-        assert is_exception
+        # Incorrect response "apple" returned to user
+        resp_txt = get_text_response(response)
+        # log.info(f"Inccorect response = {resp_txt} is returned")
+        assert answer[0] == resp_txt
 
     @pytest.mark.tags("L1")
     def test_cache_health_check(self):

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -136,3 +136,5 @@ class TestSqliteMilvus(Base):
                 stream=True,
             )
             assert get_text_response(response) == answer[0]
+            if os.path.isfile("./sqlite.db"):
+                os.remove("./sqlite.db")

--- a/tests/integration_tests/test_sqlite_milvus_sbert.py
+++ b/tests/integration_tests/test_sqlite_milvus_sbert.py
@@ -97,7 +97,7 @@ class TestSqliteMilvus(Base):
         """
         target: test hit the cache function
         method: keep default similarity_threshold
-        expected: hit successfully but return wrong reponse to user
+        expected: cache hit with cache check enabled
         """
         if os.path.isfile("./sqlite.db"):
             os.remove("./sqlite.db")


### PR DESCRIPTION
**What is it**: For GPTCache to work correctly, the cache store and vector store must be in sync with each other, i.e., any discrepency between the two will cause erroneous cache hit and consequently return incorrect response back to user. There exists many reasons to cause both store out of sync with each other unintentionally in live production environment, therefore the consistency between cache store and vector store should be explictly checked instead of taking for granted, so that we add fault tolerance into the system by design.

This feature address this by adding cache self-check into SearchDistanceEvaluation Class. In the event of inconsistency is found, not only preventing wrong response sent to user, cache can also self-heal by replacing problematic entries such that the cache will achieve in-sync gradually over time.

**How it works**: we check embeddings from vector store and embeddings from cache store by same ID, they should be identical if both stores are in sync, otherwise out-of-sync is detected. When out-of-sync is detected, we manipute distance returned by vector search to infinity to prevent cache hit. At same time, we replace the out-of-sync entry in vector store by ID and embeddings from the cache store, so next timer around, we don't have this out-of-sync entry any more.

**How to use it**:  unit test file is provided to showcase GPTCache bebaviour with & without this feature. This feature is turned off by default so it is compatible with existing codebase. For start, this feature has been implmented for Chroma & Milvus vector store respectively. 