### PR TITLE
[BUG] search_result distances may come as strings

### DIFF
--- a/gptcache/similarity_evaluation/distance.py
+++ b/gptcache/similarity_evaluation/distance.py
@@ -46,6 +46,7 @@ class SearchDistanceEvaluation(SimilarityEvaluation):
         :return: evaluation score.
         """
         distance, _ = cache_dict["search_result"]
+        distance = float(distance)
         if distance < 0:
             distance = 0
         elif distance > self.max_distance:

--- a/tests/unit_tests/similarity_evaluation/test_simple.py
+++ b/tests/unit_tests/similarity_evaluation/test_simple.py
@@ -21,6 +21,8 @@ def _test_evaluation_config(evaluation):
     assert math.isclose(range_min, 0.0)
     assert math.isclose(range_max, 10.0)
 
+    score = evaluation.evaluation({}, {"search_result": ('2.5', None)})
+    assert math.isclose(score, 5.0)
     score = evaluation.evaluation({}, {"search_result": (5, None)})
     assert math.isclose(score, 5.0)
     score = evaluation.evaluation({}, {"search_result": (20, None)})


### PR DESCRIPTION
While testing GPTCache with PostrgreSQL as `cache_base` and RedisVectorStore as `vector_base`, along with `SearchDistanceEvaluation` as `similarity_evaluation` an error occurs, because the distance value in `cache_dict` is a `str` and then it can't be compared with 0 right from the start.

I added a cast to float in order to fix the Bug.