### PR TITLE
NumpyNormEvaluation numpy error fix

### DIFF
--- a/gptcache/similarity_evaluation/np.py
+++ b/gptcache/similarity_evaluation/np.py
@@ -68,7 +68,7 @@ class NumpyNormEvaluation(SimilarityEvaluation):
         if 'question' in src_dict and 'question' in cache_dict:
             if src_dict['question'].lower() == cache_dict['question'].lower():
                 return self.range()[1]
-            if 'embedding' not in src_dict or 'embedding' not in cache_dict or not src_dict['embedding'] or not cache_dict['embedding']:
+            if 'embedding' not in src_dict or 'embedding' not in cache_dict or src_dict['embedding'] is None or cache_dict['embedding'] is None:
                 assert self.question_encoder, 'You need to a valid question_embedding_function to generate question embedding in the evaluator.'
                 src_dict['embedding'] = self.question_encoder(src_dict['question'])
                 cache_dict['embedding'] = self.question_encoder(cache_dict['question'])


### PR DESCRIPTION
When I ran the following code:
```python
## Embedding Function
embeddings = OpenAIEmbeddings(model="text-embedding-ada-002")
encoder = LangChain(embeddings=embeddings)


## Data Manager
redis_cache_storage = CacheBase(name="redis", redis_host="localhost", redis_port=6379)
redis_vector_storage = VectorBase(
    name="redis", host="localhost", port=6379, dimension=1536
)
data_manager = get_data_manager(redis_cache_storage, redis_vector_storage)

init_similar_cache(
    embedding=encoder,
    data_manager=data_manager,
    evaluation=NumpyNormEvaluation(),
    data_dir=f"similar_cache",
    config=Config(similarity_threshold=0.2),
)

put("apple", "boy")
print(get("appl"))
```

I was getting the following error:

```console

Traceback (most recent call last):
  File "/home/mohtashimkhan/GPTCache/test.py", line 36, in <module>
    print(get("appl"))
  File "/home/mohtashimkhan/GPTCache/gptcache/adapter/api.py", line 124, in get
    res = adapt(
  File "/home/mohtashimkhan/GPTCache/gptcache/adapter/adapter.py", line 158, in adapt
    rank = time_cal(
  File "/home/mohtashimkhan/GPTCache/gptcache/utils/time.py", line 9, in inner
    res = func(*args, **kwargs)
  File "/home/mohtashimkhan/GPTCache/gptcache/similarity_evaluation/np.py", line 71, in evaluation
    if 'embedding' not in src_dict or 'embedding' not in cache_dict or not src_dict['embedding'] or not cache_dict['embedding']:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

```
Numpy was raising a ValueError because the not operator with a numpy array was not reducing to a single boolean value. Therefore, I decided to explicitly check if the array is None, which resolved the issue.



