### PR TITLE
LangChainLLMs cache_obj update

### DIFF
--- a/gptcache/adapter/langchain_models.py
+++ b/gptcache/adapter/langchain_models.py
@@ -4,6 +4,7 @@ from gptcache.adapter.adapter import adapt, aadapt
 from gptcache.manager.scalar_data.base import Answer, DataType
 from gptcache.session import Session
 from gptcache.utils import import_pydantic, import_langchain
+from gptcache.core import Cache,cache
 
 import_pydantic()
 import_langchain()
@@ -50,6 +51,7 @@ class LangChainLLMs(LLM, BaseModel):
 
     llm: Any
     session: Session = None
+    cache_obj: Cache = cache
     tmp_args: Any = None
 
     @property
@@ -80,6 +82,7 @@ class LangChainLLMs(LLM, BaseModel):
             _update_cache_callback,
             prompt=prompt,
             stop=stop,
+            cache_obj=self.cache_obj,
             session=session,
             **self.tmp_args,
         )
@@ -151,6 +154,7 @@ class LangChainChat(BaseChatModel, BaseModel):
 
     chat: Any
     session: Session = None
+    cache_obj: Cache = cache
     tmp_args: Any = None
 
     def _generate(
@@ -170,6 +174,7 @@ class LangChainChat(BaseChatModel, BaseModel):
             _update_cache_msg_callback,
             messages=messages,
             stop=stop,
+            cache_obj=self.cache_obj,
             session=session,
             run_manager=run_manager,
             **self.tmp_args,
@@ -193,6 +198,7 @@ class LangChainChat(BaseChatModel, BaseModel):
             _update_cache_msg_callback,
             messages=messages,
             stop=stop,
+            cache_obj=self.cache_obj,
             session=session,
             run_manager=run_manager,
             **self.tmp_args,

--- a/tests/unit_tests/adapter/test_langchain_models.py
+++ b/tests/unit_tests/adapter/test_langchain_models.py
@@ -30,7 +30,7 @@ def test_langchain_llms():
 
     os.environ["OPENAI_API_KEY"] = "API"
     langchain_openai = OpenAI(model_name="text-ada-001")
-    llm = LangChainLLMs(llm=langchain_openai)
+    llm = LangChainLLMs(llm=langchain_openai,cache_obj=llm_cache)
     assert str(langchain_openai) == str(llm)
 
     with patch("openai.Completion.create") as mock_create:
@@ -53,10 +53,10 @@ def test_langchain_llms():
               }
             }
 
-        answer = llm(prompt=question, cache_obj=llm_cache)
+        answer = llm(prompt=question)
         assert expect_answer == answer
 
-    answer = llm(prompt=question, cache_obj=llm_cache)
+    answer = llm(prompt=question)
     assert expect_answer == answer
 
 
@@ -77,7 +77,7 @@ def test_langchain_chats():
 
     os.environ["OPENAI_API_KEY"] = "API"
     langchain_openai = ChatOpenAI(temperature=0)
-    chat = LangChainChat(chat=langchain_openai)
+    chat = LangChainChat(chat=langchain_openai,cache_obj=llm_cache)
 
     assert chat.get_num_tokens("hello") == langchain_openai.get_num_tokens("hello")
     assert chat.get_num_tokens_from_messages(messages=[HumanMessage(content="test_langchain_chats")]) \
@@ -104,7 +104,7 @@ def test_langchain_chats():
             }
         }
 
-        answer = chat(messages=question, cache_obj=llm_cache)
+        answer = chat(messages=question)
         assert answer == _cache_msg_data_convert(msg).generations[0].message
 
     with patch("openai.ChatCompletion.acreate") as mock_create:
@@ -128,16 +128,16 @@ def test_langchain_chats():
             }
         }
 
-        answer = asyncio.run(chat.agenerate([question2], cache_obj=llm_cache))
+        answer = asyncio.run(chat.agenerate([question2]))
         assert answer.generations[0][0].text == _cache_msg_data_convert(msg).generations[0].text
 
-    answer = chat(messages=question, cache_obj=llm_cache)
+    answer = chat(messages=question)
     assert answer == _cache_msg_data_convert(msg).generations[0].message
 
-    answer = asyncio.run(chat.agenerate([question], cache_obj=llm_cache))
+    answer = asyncio.run(chat.agenerate([question]))
     assert answer.generations[0][0].text == _cache_msg_data_convert(msg).generations[0].text
 
-    answer = asyncio.run(chat.agenerate([question2], cache_obj=llm_cache))
+    answer = asyncio.run(chat.agenerate([question2]))
     assert answer.generations[0][0].text == _cache_msg_data_convert(msg).generations[0].text
 
 


### PR DESCRIPTION
If one were required to pass a custom cache_obj, it would necessitate passing the cache_obj during inference time, potentially leading to repetitive passes of the cache_obj. However, with this PR, such repetition will no longer be necessary:

```python
from gptcache import cache
from gptcache.core import Cache
from gptcache.processor.pre import get_prompt,get_messages_last_content
from gptcache.processor.pre import get_messages_last_content
from langchain.llms import OpenAI
from gptcache.adapter.langchain_models import LangChainLLMs
import os
os.environ['OPENAI_API_KEY']="KEY"

# init gptcache
llm_cache = Cache()
llm_cache.init(
    pre_embedding_func=get_prompt,
)


# run llm with gptcache
llm = LangChainLLMs(llm=OpenAI(temperature=0) , cache_obj = llm_cache) ## passing cache_obj once
llm("Hello world") ## Not during inference
llm("How are you?") ## Not during inference
```

Furthermore, the current limitation of not being able to pass cache_obj during the construction of `LangChainLLMs` prevents you from using a custom cache_obj in other sequential chains like `SQLDatabaseSequentialChain`, where only the global cache object can be used. This restriction arises because there is no provision to pass a custom cache_obj when SQLDatabaseSequentialChain calls the predict method.

However, with the implementation of my update, you will have the ability to initialize LangChainLLMs with a custom cache_obj. As a result, when you pass this LangChainLLMs instance into the chain, custom cache_obj will function correctly:

```python
from gptcache import cache
from gptcache.core import Cache
from gptcache.processor.pre import get_prompt,get_messages_last_content
from gptcache.processor.pre import get_messages_last_content
from langchain.llms import OpenAI
from gptcache.adapter.langchain_models import LangChainLLMs
from langchain_experimental.sql.base import (
    SQLDatabaseSequentialChain,
)
import os

os.environ['OPENAI_API_KEY']="KEY"
llm_cache = Cache()
llm_cache.init(
  pre_embedding_func=get_prompt,
)
# run llm with gptcache
llm = LangChainLLMs(llm=OpenAI(temperature=0) , cache_obj = llm_cache)
SQLDatabaseSequentialChain.from_llm(
chain_llm,
database=chain_db,
query_prompt=prompt,
decider_prompt=decider_prompt
) 
```
I hope this clarfies the use case and why this will improve the usability of the package.
