### PR TITLE
Use the fixed version of usearch lib

### DIFF
--- a/gptcache/utils/__init__.py
+++ b/gptcache/utils/__init__.py
@@ -93,7 +93,7 @@ def import_uform():
 
 
 def import_usearch():
-    _check_library("usearch")
+    _check_library("usearch", package="usearch==0.22.3")
 
 
 def import_torch():


### PR DESCRIPTION
Using the latest version will cause compatibility issues. In order to ensure usability, a fixed version is used.

![image](https://github.com/zilliztech/GPTCache/assets/21985684/aa4a765a-7d37-47e3-8440-6c2ef8c7ff9f)
