### PR TITLE
Distributed cache feature using Redis

### DIFF
--- a/examples/eviction/distributed_eviction.py
+++ b/examples/eviction/distributed_eviction.py
@@ -1,0 +1,73 @@
+from gptcache import Cache
+from gptcache.embedding import Onnx
+
+from gptcache.manager.eviction import EvictionBase
+
+from gptcache.manager import get_data_manager, CacheBase, VectorBase, manager_factory
+
+
+def get_data_manager_example():
+    """
+    This example shows how to create a data manager with a mongo as a scalar storage, faiss vector base,
+    and redis eviction base.
+    This type of configuration can be used to scale GPTCache horizontally.
+    Where keys will be maintained in redis key-value store instead of in-memory.
+    The eviction of the keys will be handled based on the eviction policy of redis.
+    """
+    onnx = Onnx()
+    data_manager = get_data_manager(cache_base=CacheBase("mongo", url="mongodb://localhost:27017/"),
+                                    vector_base=VectorBase("faiss", dimension=onnx.dimension),
+                                    eviction_base=EvictionBase("redis",
+                                                               maxmemory="100mb",
+                                                               policy="allkeys-lru",
+                                                               ttl=100))
+
+    cache = Cache()
+    cache.init(data_manager=data_manager)
+    question = "What is github?"
+    answer = "Online platform for version control and code collaboration."
+    embedding = onnx.to_embeddings(question)
+    cache.import_data([question], [answer], [embedding])
+
+
+def get_manager_example_redis_only():
+    """
+    Note: Since, `RedisScalarStorage` can be configured to internally handle the ttl of the keys and their eviction.
+    In this scenario, `no_op_eviction` is used as the eviction base. It will not add any keys or update their ttls.
+
+    This example shows how to create a data manager with a redis as a scalar storage, as well as eviction base.
+    This type of configuration can be used to scale GPTCache horizontally.
+    Where keys will be maintained in redis key-value store instead of in-memory.
+    The eviction of the keys will be handled based on the eviction policy of redis.
+
+    """
+    onnx = Onnx()
+    data_manager = get_data_manager(cache_base=CacheBase("redis", maxmemory="100mb", policy="allkeys-lru", ttl=100),
+                                    vector_base=VectorBase("faiss", dimension=onnx.dimension),
+                                    eviction_base=EvictionBase("no_op_eviction"))
+
+    cache = Cache()
+    cache.init(data_manager=data_manager)
+    question = "What is github?"
+    answer = "Online platform for version control and code collaboration."
+    embedding = onnx.to_embeddings(question)
+    cache.import_data([question], [answer], [embedding])
+
+
+def manager_factory_example():
+    onnx = Onnx()
+    data_manager = manager_factory("redis,faiss",
+                                   eviction_manager="redis",
+                                   scalar_params={"url": "redis://localhost:6379"},
+                                   vector_params={"dimension": onnx.dimension},
+                                   eviction_params={"maxmemory": "100mb",
+                                                    "policy": "allkeys-lru",
+                                                    "ttl": 1}
+                                   )
+
+    cache = Cache()
+    cache.init(data_manager=data_manager)
+    question = "What is github?"
+    answer = "Online platform for version control and code collaboration."
+    embedding = onnx.to_embeddings(question)
+    cache.import_data([question], [answer], [embedding])

--- a/gptcache/manager/data_manager.py
+++ b/gptcache/manager/data_manager.py
@@ -31,11 +31,11 @@ class DataManager(metaclass=ABCMeta):
 
     @abstractmethod
     def import_data(
-        self,
-        questions: List[Any],
-        answers: List[Any],
-        embedding_datas: List[Any],
-        session_ids: List[Optional[str]],
+            self,
+            questions: List[Any],
+            answers: List[Any],
+            embedding_datas: List[Any],
+            session_ids: List[Optional[str]],
     ):
         pass
 
@@ -225,15 +225,24 @@ class SSDataManager(DataManager):
         s: CacheStorage,
         v: VectorBase,
         o: Optional[ObjectBase],
-        e: Optional[EvictionBase]
+        e: Optional[EvictionBase],
+        max_size,
+        clean_size,
+        policy="LRU"
     ):
         self.s = s
         self.v = v
         self.o = o
         self.eviction_manager = EvictionManager(self.s, self.v)
+        if e is None:
+            e = EvictionBase(name="memory",
+                             maxsize=max_size,
+                             clean_size=clean_size,
+                             policy=policy,
+                             on_evict=self._clear)
         self.eviction_base = e
 
-        if self.eviction_base is not NoOpEviction:
+        if not isinstance(self.eviction_base, NoOpEviction):
             # if eviction manager is no op redis, we don't need to put data into eviction base
             self.eviction_base.put(self.s.get_ids(deleted=False))
 

--- a/gptcache/manager/eviction/distributed_cache.py
+++ b/gptcache/manager/eviction/distributed_cache.py
@@ -47,10 +47,12 @@ class RedisCacheEviction(DistributedEviction, ABC):
     :type maxmemory: str
     :param global_key_prefix: the global key prefix
     :type global_key_prefix: str
-    :param kwargs: the kwargs
-    :type kwargs: Any
     :param ttl: the ttl of the cache data
     :type ttl: int
+    :param maxmemory_samples: Number of keys to sample when evicting keys
+    :type maxmemory_samples: int
+    :param kwargs: the kwargs
+    :type kwargs: Any
     """
 
     def __init__(self,

--- a/gptcache/manager/eviction/distributed_cache.py
+++ b/gptcache/manager/eviction/distributed_cache.py
@@ -60,13 +60,17 @@ class RedisCacheEviction(DistributedEviction, ABC):
                  policy: str = None,
                  global_key_prefix="gptcache",
                  ttl: int = None,
+                 maxmemory_samples: int = None,
                  **kwargs):
         self._redis = get_redis_connection(host=host, port=port, **kwargs)
         if maxmemory:
             self._redis.config_set("maxmemory", maxmemory)
+        if maxmemory_samples:
+            self._redis.config_set("maxmemory-samples", maxmemory_samples)
         if policy:
             self._redis.config_set("maxmemory-policy", policy)
             self._policy = policy.lower()
+
         self._global_key_prefix = global_key_prefix
         self._ttl = ttl
 

--- a/gptcache/manager/eviction/distributed_cache.py
+++ b/gptcache/manager/eviction/distributed_cache.py
@@ -1,0 +1,59 @@
+from abc import ABC
+from typing import Any, List, Callable
+
+import redis
+from redis_om import get_redis_connection
+
+from gptcache.manager.eviction.base import EvictionBase
+from gptcache.manager.scalar_data.redis_storage import RedisCacheStorage
+
+
+class DistributedCacheEviction(EvictionBase, ABC):
+    """eviction: Distributed Cache
+    :param host: the host of redis
+    :type host: str
+    :param port: the port of redis
+    :type port: int
+    :param policy: eviction strategy
+    :type policy: str
+    :param maxsize: the maxsize of cache data
+    :type maxsize: int
+    :param on_evict: the function for cleaning the data in the store
+    :type  on_evict: Callable[[List[Any]], None]
+    :param maxmemory: the maxmemory of redis
+    :type maxmemory: str
+
+    """
+
+    def __init__(self,
+                 host='localhost',
+                 port=6379,
+                 maxmemory: str = '100mb',
+                 policy: str = 'allkeys-lru',
+                 redis_cache_storage: RedisCacheStorage = None,
+                 **kwargs):
+        self._redis = get_redis_connection(host=host, port=port, **kwargs)
+        self._redis.config_set('maxmemory', maxmemory)
+        self._redis.config_set('maxmemory-policy', policy)
+        self._policy = policy.lower()
+        self._s = redis_cache_storage
+
+    def put(self, objs: List[Any], ttl: int = None):
+        if not self._s:
+            for obj in objs:
+                self._redis.set(obj, "True")
+
+    def get(self, key: str):
+        if self._s:
+            return self._s.get_data_by_id(key)
+
+        try:
+            value = self._redis.get(key)
+            return value
+        except redis.RedisError:
+            print(f"Error getting key {key} from cache")
+            return None
+
+    @property
+    def policy(self) -> str:
+        return self._policy

--- a/gptcache/manager/eviction/distributed_cache.py
+++ b/gptcache/manager/eviction/distributed_cache.py
@@ -5,13 +5,13 @@ import redis
 from redis_om import get_redis_connection
 
 from gptcache.manager.eviction.base import EvictionBase
-from gptcache.manager.scalar_data.redis_storage import RedisCacheStorage
 
 
 class DistributedEviction(EvictionBase, ABC):
     """
     Base class for Distributed Eviction Strategy.
     """
+
     @abstractmethod
     def put(self, keys: List[str]):
         pass
@@ -42,8 +42,6 @@ class RedisCacheEviction(DistributedEviction, ABC):
     :type  on_evict: Callable[[List[Any]], None]
     :param maxmemory: the maxmemory of redis
     :type maxmemory: str
-    :param redis_cache_storage: the redis cache storage
-    :type redis_cache_storage: RedisCacheStorage
     :param global_key_prefix: the global key prefix
     :type global_key_prefix: str
     :param kwargs: the kwargs

--- a/gptcache/manager/eviction/distributed_cache.py
+++ b/gptcache/manager/eviction/distributed_cache.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, Callable
+from typing import List
 
 import redis
 from redis_om import get_redis_connection
@@ -9,7 +9,9 @@ from gptcache.manager.scalar_data.redis_storage import RedisCacheStorage
 
 
 class DistributedEviction(EvictionBase, ABC):
-
+    """
+    Base class for Distributed Eviction Strategy.
+    """
     @abstractmethod
     def put(self, keys: List[str]):
         pass
@@ -51,7 +53,7 @@ class RedisCacheEviction(DistributedEviction, ABC):
     """
 
     def __init__(self,
-                 host='localhost',
+                 host="localhost",
                  port=6379,
                  maxmemory: str = None,
                  policy: str = None,
@@ -60,9 +62,9 @@ class RedisCacheEviction(DistributedEviction, ABC):
                  **kwargs):
         self._redis = get_redis_connection(host=host, port=port, **kwargs)
         if maxmemory:
-            self._redis.config_set('maxmemory', maxmemory)
+            self._redis.config_set("maxmemory", maxmemory)
         if policy:
-            self._redis.config_set('maxmemory-policy', policy)
+            self._redis.config_set("maxmemory-policy", policy)
             self._policy = policy.lower()
         self._global_key_prefix = global_key_prefix
         self._ttl = ttl

--- a/gptcache/manager/eviction/distributed_cache.py
+++ b/gptcache/manager/eviction/distributed_cache.py
@@ -1,3 +1,4 @@
+# pylint: disable=wrong-import-position
 from abc import ABC, abstractmethod
 from typing import List
 

--- a/gptcache/manager/eviction/distributed_cache.py
+++ b/gptcache/manager/eviction/distributed_cache.py
@@ -3,13 +3,11 @@ from abc import ABC, abstractmethod
 from typing import List
 
 from gptcache.utils import import_redis
+from gptcache.manager.eviction.base import EvictionBase
 
 import_redis()
-
 import redis
 from redis_om import get_redis_connection
-
-from gptcache.manager.eviction.base import EvictionBase
 
 
 class DistributedEviction(EvictionBase, ABC):

--- a/gptcache/manager/eviction/manager.py
+++ b/gptcache/manager/eviction/manager.py
@@ -18,8 +18,8 @@ class EvictionBase:
     @staticmethod
     def get(
         name: str,
-        policy: str,
-        maxsize: int,
+        policy: str = "LRU",
+        maxsize: int = 1000,
         clean_size: int = 0,
         on_evict: Callable[[List[Any]], None] = None,
         **kwargs
@@ -32,9 +32,15 @@ class EvictionBase:
             eviction_base = MemoryCacheEviction(
                 policy, maxsize, clean_size, on_evict, **kwargs
             )
-        if name in "distributed":
-            from gptcache.manager.eviction.distributed_cache import DistributedCacheEviction
-            eviction_base = DistributedCacheEviction(**kwargs)
+            return eviction_base
+        if name is "redis":
+            from gptcache.manager.eviction.distributed_cache import RedisCacheEviction
+            eviction_base = RedisCacheEviction(policy=policy, **kwargs)
+            return eviction_base
+        if name is "no_op_eviction":
+            from gptcache. manager.eviction.distributed_cache import NoOpEviction
+            eviction_base = NoOpEviction()
+            return eviction_base
+
         else:
             raise NotFoundError("eviction base", name)
-        return eviction_base

--- a/gptcache/manager/eviction/manager.py
+++ b/gptcache/manager/eviction/manager.py
@@ -35,6 +35,8 @@ class EvictionBase:
             return eviction_base
         if name is "redis":
             from gptcache.manager.eviction.distributed_cache import RedisCacheEviction
+            if policy is "LRU":
+                policy = None
             eviction_base = RedisCacheEviction(policy=policy, **kwargs)
             return eviction_base
         if name is "no_op_eviction":

--- a/gptcache/manager/eviction/manager.py
+++ b/gptcache/manager/eviction/manager.py
@@ -33,13 +33,13 @@ class EvictionBase:
                 policy, maxsize, clean_size, on_evict, **kwargs
             )
             return eviction_base
-        if name is "redis":
+        if name == "redis":
             from gptcache.manager.eviction.distributed_cache import RedisCacheEviction
-            if policy is "LRU":
+            if policy == "LRU":
                 policy = None
             eviction_base = RedisCacheEviction(policy=policy, **kwargs)
             return eviction_base
-        if name is "no_op_eviction":
+        if name == "no_op_eviction":
             from gptcache. manager.eviction.distributed_cache import NoOpEviction
             eviction_base = NoOpEviction()
             return eviction_base

--- a/gptcache/manager/eviction/manager.py
+++ b/gptcache/manager/eviction/manager.py
@@ -32,6 +32,9 @@ class EvictionBase:
             eviction_base = MemoryCacheEviction(
                 policy, maxsize, clean_size, on_evict, **kwargs
             )
+        if name in "distributed":
+            from gptcache.manager.eviction.distributed_cache import DistributedCacheEviction
+            eviction_base = DistributedCacheEviction(**kwargs)
         else:
             raise NotFoundError("eviction base", name)
         return eviction_base

--- a/gptcache/manager/eviction/memory_cache.py
+++ b/gptcache/manager/eviction/memory_cache.py
@@ -33,12 +33,12 @@ class MemoryCacheEviction(EvictionBase):
     """
 
     def __init__(
-        self,
-        policy: str,
-        maxsize: int,
-        clean_size: int = 0,
-        on_evict: Callable[[List[Any]], None] = None,
-        **kwargs,
+            self,
+            policy: str = "LRU",
+            maxsize: int = 1000,
+            clean_size: int = 0,
+            on_evict: Callable[[List[Any]], None] = None,
+            **kwargs,
     ):
         self._policy = policy.upper()
         if self._policy == "LRU":

--- a/gptcache/manager/factory.py
+++ b/gptcache/manager/factory.py
@@ -10,6 +10,7 @@ def manager_factory(manager="map",
                     data_dir="./",
                     max_size=1000,
                     clean_size=None,
+                    eviction_manager:str = "memory",
                     eviction: str = "LRU",
                     get_data_container: Callable = None,
                     scalar_params=None,
@@ -87,7 +88,7 @@ def manager_factory(manager="map",
     if obj == "local":
         object_params["path"] = os.path.join(data_dir, "local_obj")
     o = ObjectBase(name=obj, **object_params) if obj else None
-    return get_data_manager(s, v, o, max_size, clean_size, eviction)
+    return get_data_manager(s, v, o, max_size, clean_size, eviction_manager, eviction)
 
 
 def get_data_manager(
@@ -96,6 +97,7 @@ def get_data_manager(
     object_base: Union[ObjectBase, str] = None,
     max_size: int = 1000,
     clean_size: int = None,
+    eviction_manager="memory",
     eviction: str = "LRU",
     data_path: str = "data_map.txt",
     get_data_container: Callable = None,
@@ -121,6 +123,8 @@ def get_data_manager(
     :type data_path:  str
     :param get_data_container: a Callable to get the data container, defaults to None.
     :type get_data_container:  Callable
+    :param eviction_manager: the eviction manager, defaults to "memory".
+    :type eviction_manager:  str
 
 
     :return: SSDataManager or MapDataManager.
@@ -142,4 +146,5 @@ def get_data_manager(
     if isinstance(object_base, str):
         object_base = ObjectBase(name=object_base)
     assert cache_base and vector_base
-    return SSDataManager(cache_base, vector_base, object_base, max_size, clean_size, eviction)
+    return SSDataManager(cache_base, vector_base, object_base, max_size, clean_size,
+                         eviction_manager=eviction_manager, policy=eviction)

--- a/gptcache/manager/factory.py
+++ b/gptcache/manager/factory.py
@@ -115,7 +115,8 @@ def manager_factory(manager="map",
         s.init_eviction_params(
             maxmemory=eviction_params.get("maxmemory", scalar_params.get("maxmemory")),
             policy=eviction_params.get("policy", scalar_params.get("policy")),
-            ttl=eviction_params.get("ttl", scalar_params.get("ttl"))
+            ttl=eviction_params.get("ttl", scalar_params.get("ttl")),
+            maxmemory_samples=eviction_params.get("maxmemory_samples", scalar_params.get("maxmemory_samples")),
         )
 
     e = EvictionBase(

--- a/gptcache/manager/factory.py
+++ b/gptcache/manager/factory.py
@@ -2,21 +2,25 @@ import os
 from pathlib import Path
 from typing import Union, Callable
 
+from gptcache.utils.log import gptcache_log
+
+from gptcache.manager.eviction import EvictionBase
+
 from gptcache.manager import CacheBase, VectorBase, ObjectBase
 from gptcache.manager.data_manager import SSDataManager, MapDataManager
+from gptcache.manager.scalar_data.redis_storage import RedisCacheStorage
 
 
 def manager_factory(manager="map",
                     data_dir="./",
                     max_size=1000,
-                    clean_size=None,
-                    eviction_manager:str = "memory",
-                    eviction: str = "LRU",
+                    eviction_manager: str = "memory",
                     get_data_container: Callable = None,
                     scalar_params=None,
                     vector_params=None,
-                    object_params=None):
-
+                    object_params=None,
+                    eviction_params=None
+                    ):
     """Factory of DataManager.
        By using this factory method, you only need to specify the root directory of the data,
        and it can automatically manage all the local files.
@@ -26,12 +30,10 @@ def manager_factory(manager="map",
     :type manager: str
     :param data_dir: Root path for data storage.
     :type data_dir: str
-    :param max_size: the max size for the cache, defaults to 1000.
+    :param max_size: the max size for the LRU cache in MapDataManager, defaults to 1000.
     :type max_size: int
-    :param clean_size: the size to clean up, defaults to `max_size * 0.2`.
-    :type clean_size: int
-    :param eviction: the eviction policy, it is support "LRU" and "FIFO" now, and defaults to "LRU".
-    :type eviction:  str
+    :param eviction_manager: the eviction manager, defaults to "memory". It supports "memory" and "redis".
+    :type eviction_manager:  str
     :param get_data_container: a Callable to get the data container, defaults to None.
     :type get_data_container:  Callable
 
@@ -44,6 +46,8 @@ def manager_factory(manager="map",
     :param object_params: Params of object storage.
     :type object_params:  dict
 
+    :param eviction_params: Params of eviction.
+    :type eviction_params:  dict
     :return: SSDataManager or MapDataManager.
 
     Example:
@@ -62,7 +66,8 @@ def manager_factory(manager="map",
 
     db_infos = manager.split(",")
     if len(db_infos) not in [2, 3]:
-        raise RuntimeError("Error manager format: %s, the correct is \"{scalar},{vector},{object}\", object is optional" % manager)
+        raise RuntimeError(
+            "Error manager format: %s, the correct is \"{scalar},{vector},{object}\", object is optional" % manager)
 
     if len(db_infos) == 2:
         db_infos.append("")
@@ -88,19 +93,36 @@ def manager_factory(manager="map",
     if obj == "local":
         object_params["path"] = os.path.join(data_dir, "local_obj")
     o = ObjectBase(name=obj, **object_params) if obj else None
-    return get_data_manager(s, v, o, max_size, clean_size, eviction_manager, eviction)
+
+    if eviction_params is None:
+        eviction_params = {}
+
+    if type(s) == RedisCacheStorage and eviction_manager == "redis":
+        # if cache manager and eviction manager are both redis, we use no op redis to avoid redundant operations
+        eviction_manager = "no_op_eviction"
+        gptcache_log.info("Since Scalar Storage and Eviction manager are both redis, "
+                          "no_op_eviction will be used to avoid redundant operations.")
+        s.init_eviction_params(
+            maxmemory=eviction_params.get("maxmemory", scalar_params.get("maxmemory")),
+            policy=eviction_params.get("policy", scalar_params.get("policy")),
+            ttl=eviction_params.get("ttl", scalar_params.get("ttl"))
+           )
+
+    e = EvictionBase(
+        name=eviction_manager,
+        **eviction_params
+    )
+    return get_data_manager(s, v, o, e)
 
 
 def get_data_manager(
-    cache_base: Union[CacheBase, str] = None,
-    vector_base: Union[VectorBase, str] = None,
-    object_base: Union[ObjectBase, str] = None,
-    max_size: int = 1000,
-    clean_size: int = None,
-    eviction_manager="memory",
-    eviction: str = "LRU",
-    data_path: str = "data_map.txt",
-    get_data_container: Callable = None,
+        cache_base: Union[CacheBase, str] = None,
+        vector_base: Union[VectorBase, str] = None,
+        object_base: Union[ObjectBase, str] = None,
+        eviction_base: Union[EvictionBase, str] = None,
+        max_size: int = 1000,
+        data_path: str = "data_map.txt",
+        get_data_container: Callable = None,
 ):
     """Generate `SSDataManager` (with `cache_base`, `vector_base`, `max_size`, `clean_size` and `eviction` params),
        or `MAPDataManager` (with `data_path`, `max_size` and `get_data_container` params) to manager the data.
@@ -113,18 +135,14 @@ def get_data_manager(
     :type vector_base: :class:`VectorBase` or str
     :param object_base: a object storage, supports local path and s3.
     :type object_base: :class:`ObjectBase` or str
-    :param max_size: the max size for the cache, defaults to 1000.
+    :param max_size: the max size for the LRU cache in MapDataManager, defaults to 1000.
     :type max_size: int
-    :param clean_size: the size to clean up, defaults to `max_size * 0.2`.
-    :type clean_size: int
-    :param eviction: the eviction policy, it is support "LRU" and "FIFO" now, and defaults to "LRU".
-    :type eviction:  str
+    :param eviction_base: a EvictionBase object, or the name of the eviction, it is support 'memory' and 'redis'.
+    :type eviction_base: :class:`EvictionBase` or str
     :param data_path: the path to save the map data, defaults to 'data_map.txt'.
     :type data_path:  str
     :param get_data_container: a Callable to get the data container, defaults to None.
     :type get_data_container:  Callable
-    :param eviction_manager: the eviction manager, defaults to "memory".
-    :type eviction_manager:  str
 
 
     :return: SSDataManager or MapDataManager.
@@ -146,5 +164,4 @@ def get_data_manager(
     if isinstance(object_base, str):
         object_base = ObjectBase(name=object_base)
     assert cache_base and vector_base
-    return SSDataManager(cache_base, vector_base, object_base, max_size, clean_size,
-                         eviction_manager=eviction_manager, policy=eviction)
+    return SSDataManager(cache_base, vector_base, object_base, eviction_base)

--- a/gptcache/manager/factory.py
+++ b/gptcache/manager/factory.py
@@ -109,7 +109,7 @@ def manager_factory(manager="map",
     if eviction_params is None:
         eviction_params = {}
 
-    if type(s) == RedisCacheStorage and eviction_manager == "redis":
+    if s is RedisCacheStorage and eviction_manager == "redis":
         # if cache manager and eviction manager are both redis, we use no op redis to avoid redundant operations
         eviction_manager = "no_op_eviction"
         gptcache_log.info("Since Scalar Storage and Eviction manager are both redis, "

--- a/gptcache/manager/scalar_data/redis_storage.py
+++ b/gptcache/manager/scalar_data/redis_storage.py
@@ -53,6 +53,7 @@ def get_models(global_key: str, redis_connection: Redis):
         Custom type for embedding data. This will be stored as bytes in redis.
         Latin-1 encoding is used to convert the bytes to string and vice versa.
         """
+
         def __init__(self, data: bytes):
             self.data = data
 
@@ -74,7 +75,7 @@ def get_models(global_key: str, redis_connection: Redis):
             field_schema.update(type="string", format="byte")
 
         def to_numpy(self) -> np.ndarray:
-            return np.frombuffer(self.data.encode('latin-1'), dtype=np.float32)
+            return np.frombuffer(self.data.encode("latin-1"), dtype=np.float32)
 
         def __repr__(self):
             return f"{self.data}"
@@ -119,8 +120,8 @@ def get_models(global_key: str, redis_connection: Redis):
 
         class Config:
             json_encoders = {
-                EmbeddingType: lambda n: n.data.decode('latin-1')
-                if type(n.data) == bytes else n.data
+                EmbeddingType: lambda n: n.data.decode("latin-1")
+                if isinstance(n.data, bytes) else n.data
             }
 
     class Sessions(JsonModel):
@@ -226,9 +227,9 @@ class RedisCacheStorage(CacheStorage):
     def init_eviction_params(self, policy, maxmemory, ttl):
         self.default_ttl = ttl
         if maxmemory:
-            self.con.config_set('maxmemory', maxmemory)
+            self.con.config_set("maxmemory", maxmemory)
         if policy:
-            self.con.config_set('maxmemory-policy', policy)
+            self.con.config_set("maxmemory-policy", policy)
 
     def create(self):
         pass

--- a/gptcache/manager/scalar_data/redis_storage.py
+++ b/gptcache/manager/scalar_data/redis_storage.py
@@ -210,13 +210,8 @@ class RedisCacheStorage(CacheStorage):
             **kwargs
     ):
         self.con = get_redis_connection(host=host, port=port, **kwargs)
-        self._policy = policy
-        if maxmemory:
-            self.con.config_set('maxmemory', maxmemory)
-        if policy:
-            self.con.config_set('maxmemory-policy', policy)
         self.default_ttl = ttl
-
+        self.init_eviction_params(policy=policy, maxmemory=maxmemory, ttl=ttl)
         (
             self._ques,
             self._answer,
@@ -227,6 +222,13 @@ class RedisCacheStorage(CacheStorage):
         ) = get_models(global_key_prefix, redis_connection=self.con)
 
         Migrator().run()
+
+    def init_eviction_params(self, policy, maxmemory, ttl):
+        self.default_ttl = ttl
+        if maxmemory:
+            self.con.config_set('maxmemory', maxmemory)
+        if policy:
+            self.con.config_set('maxmemory-policy', policy)
 
     def create(self):
         pass

--- a/gptcache/manager/scalar_data/redis_storage.py
+++ b/gptcache/manager/scalar_data/redis_storage.py
@@ -47,40 +47,37 @@ def get_models(global_key: str, redis_connection: Redis):
         def get(cls):
             return cls.database.get(cls.key_name)
 
-    class Embedding:
+    class EmbeddingType:
         """
-        Custom class for storing embedding result.
-        An embedding of type ``bytes`` is stored against Hash record type for the provided key.
-        :param pk: Primary key against which hash data for embedding would be stored
-        :type pk: str
-        :param embedding: Embedding information to store
-        :type embedding: bytes
-
-        Note:
-            As of this implementation, redis-om doesn't have a good compatibility to store bytes data
-            and successfully retrieve it without corruption.
-            In addition to that, decoding while getting the response is disabled as well.
+        Directly using bytes for embedding data is not supported by redis-om as of now.
+        Custom type for embedding data. This will be stored as bytes in redis.
+        Latin-1 encoding is used to convert the bytes to string and vice versa.
         """
-
-        prefix = global_key + ":embedding"
-
-        def __init__(self, pk: str, embedding: bytes):
-            self.pk = pk
-            self.embedding = embedding
-
-        def save(self, pipeline: Pipeline):
-            pipeline.hset(self.prefix + ":" + str(self.pk), "embedding", self.embedding)
+        def __init__(self, data: bytes):
+            self.data = data
 
         @classmethod
-        def get(cls, key: int, db: Redis):
-            """
-            Returns embedding stored against the ``key``.
-            Decode only key value while creating a response
-            :param key: redis key to fetch embedding
-            :type key: str
-            """
-            result = db.hgetall(cls.prefix + ":" + str(key))
-            return {k.decode("utf-8"): v for k, v in result.items()}
+        def __get_validators__(cls):
+            yield cls.validate
+
+        @classmethod
+        def validate(cls, v: [np.array, bytes]):
+            if isinstance(v, np.ndarray):
+                return cls(v.astype(np.float32).tobytes())
+            elif isinstance(v, bytes):
+                return cls(v)
+
+            return cls(v)
+
+        @classmethod
+        def __modify_schema__(cls, field_schema):
+            field_schema.update(type="string", format="byte")
+
+        def to_numpy(self) -> np.ndarray:
+            return np.frombuffer(self.data.encode('latin-1'), dtype=np.float32)
+
+        def __repr__(self):
+            return f"{self.data}"
 
     class Answers(EmbeddedJsonModel):
         """
@@ -93,6 +90,15 @@ def get_models(global_key: str, redis_connection: Redis):
         class Meta:
             database = redis_connection
 
+    class QuestionDeps(EmbeddedJsonModel):
+        """
+        Question Dep collection
+        """
+
+        dep_name: str
+        dep_data: str
+        dep_type: int
+
     class Questions(JsonModel):
         """
         questions collection
@@ -103,11 +109,19 @@ def get_models(global_key: str, redis_connection: Redis):
         last_access: datetime.datetime
         deleted: int = Field(index=True)
         answers: List[Answers]
+        deps: List[QuestionDeps]
+        embedding: EmbeddingType
 
         class Meta:
             global_key_prefix = global_key
             model_key_prefix = "questions"
             database = redis_connection
+
+        class Config:
+            json_encoders = {
+                EmbeddingType: lambda n: n.data.decode('latin-1')
+                if type(n.data) == bytes else n.data
+            }
 
     class Sessions(JsonModel):
         """
@@ -122,21 +136,6 @@ def get_models(global_key: str, redis_connection: Redis):
         session_id: str = Field(index=True)
         session_question: str
         question_id: str = Field(index=True)
-
-    class QuestionDeps(JsonModel):
-        """
-        Question Dep collection
-        """
-
-        class Meta:
-            global_key_prefix = global_key
-            model_key_prefix = "ques_deps"
-            database = redis_connection
-
-        question_id: str = Field(index=True)
-        dep_name: str
-        dep_data: str
-        dep_type: int
 
     class Report(JsonModel):
         """
@@ -157,7 +156,7 @@ def get_models(global_key: str, redis_connection: Redis):
         cache_time: datetime.datetime = Field(index=True)
         extra: Optional[str]
 
-    return Questions, Embedding, Answers, QuestionDeps, Sessions, Counter, Report
+    return Questions, Answers, QuestionDeps, Sessions, Counter, Report
 
 
 class RedisCacheStorage(CacheStorage):
@@ -210,7 +209,6 @@ class RedisCacheStorage(CacheStorage):
 
         (
             self._ques,
-            self._embedding,
             self._answer,
             self._ques_dep,
             self._session,
@@ -235,6 +233,21 @@ class RedisCacheStorage(CacheStorage):
             )
             all_data.append(answer_data)
 
+        all_deps = []
+        if isinstance(data.question, Question) and data.question.deps is not None:
+            for dep in data.question.deps:
+                all_deps.append(
+                    self._ques_dep(
+                        dep_name=dep.name,
+                        dep_data=dep.data,
+                        dep_type=dep.dep_type,
+                    )
+                )
+        embedding_data = (
+            data.embedding_data
+            if data.embedding_data is not None
+            else None
+        )
         ques_data = self._ques(
             pk=pk,
             question=data.question
@@ -244,29 +257,11 @@ class RedisCacheStorage(CacheStorage):
             last_access=datetime.datetime.utcnow(),
             deleted=0,
             answers=answers,
+            deps=all_deps,
+            embedding=embedding_data
         )
 
         ques_data.save(pipeline)
-
-        embedding_data = (
-            data.embedding_data.astype(np.float32).tobytes()
-            if data.embedding_data is not None
-            else None
-        )
-        self._embedding(pk=ques_data.pk, embedding=embedding_data).save(pipeline)
-
-        if isinstance(data.question, Question) and data.question.deps is not None:
-            all_deps = []
-            for dep in data.question.deps:
-                all_deps.append(
-                    self._ques_dep(
-                        question_id=ques_data.pk,
-                        dep_name=dep.name,
-                        dep_data=dep.data,
-                        dep_type=dep.dep_type,
-                    )
-                )
-            self._ques_dep.add(all_deps, pipeline=pipeline)
 
         if data.session_id:
             session_data = self._session(
@@ -297,10 +292,8 @@ class RedisCacheStorage(CacheStorage):
 
         qs.update(last_access=datetime.datetime.utcnow())
         res_ans = [(item.answer, item.answer_type) for item in qs.answers]
-
-        deps = self._ques_dep.find(self._ques_dep.question_id == key).all()
         res_deps = [
-            QuestionDep(item.dep_name, item.dep_data, item.dep_type) for item in deps
+            QuestionDep(item.dep_name, item.dep_data, item.dep_type) for item in qs.deps
         ]
 
         session_ids = [
@@ -308,11 +301,10 @@ class RedisCacheStorage(CacheStorage):
             for obj in self._session.find(self._session.question_id == key).all()
         ]
 
-        res_embedding = self._embedding.get(qs.pk, self.con_encoded)["embedding"]
         return CacheData(
-            question=qs.question if not deps else Question(qs.question, res_deps),
+            question=qs.question if not res_deps else Question(qs.question, res_deps),
             answers=res_ans,
-            embedding_data=np.frombuffer(res_embedding, dtype=np.float32),
+            embedding_data=qs.embedding.to_numpy(),
             session_id=session_ids,
             create_on=qs.create_on,
             last_access=qs.last_access,
@@ -333,11 +325,6 @@ class RedisCacheStorage(CacheStorage):
                 self._session.question_id << q_ids
             ).all()
             self._session.delete_many(sessions_to_delete, pipeline)
-
-            deps_to_delete = self._ques_dep.find(
-                self._ques_dep.question_id << q_ids
-            ).all()
-            self._ques_dep.delete_many(deps_to_delete, pipeline)
 
             pipeline.execute()
 

--- a/gptcache/manager/scalar_data/redis_storage.py
+++ b/gptcache/manager/scalar_data/redis_storage.py
@@ -178,6 +178,8 @@ class RedisCacheStorage(CacheStorage):
     :type policy: str
     :param ttl: Time to live for keys in milliseconds, default value None
     :type ttl: int
+    :param maxmemory_samples: Number of keys to sample when evicting keys
+    :type maxmemory_samples: int
     :param kwargs: Additional parameters to provide in order to create redis om connection
     Example:
         .. code-block:: python

--- a/gptcache/manager/scalar_data/redis_storage.py
+++ b/gptcache/manager/scalar_data/redis_storage.py
@@ -208,11 +208,12 @@ class RedisCacheStorage(CacheStorage):
             maxmemory: str = None,
             policy: str = None,
             ttl: int = None,
+            maxmemory_samples: int = None,
             **kwargs
     ):
         self.con = get_redis_connection(host=host, port=port, **kwargs)
         self.default_ttl = ttl
-        self.init_eviction_params(policy=policy, maxmemory=maxmemory, ttl=ttl)
+        self.init_eviction_params(policy=policy, maxmemory=maxmemory, maxmemory_samples=maxmemory_samples, ttl=ttl)
         (
             self._ques,
             self._answer,
@@ -224,12 +225,14 @@ class RedisCacheStorage(CacheStorage):
 
         Migrator().run()
 
-    def init_eviction_params(self, policy, maxmemory, ttl):
+    def init_eviction_params(self, policy, maxmemory, maxmemory_samples, ttl):
         self.default_ttl = ttl
         if maxmemory:
             self.con.config_set("maxmemory", maxmemory)
         if policy:
             self.con.config_set("maxmemory-policy", policy)
+        if maxmemory_samples:
+            self.con.config_set("maxmemory-samples", maxmemory_samples)
 
     def create(self):
         pass

--- a/gptcache/manager/scalar_data/redis_storage.py
+++ b/gptcache/manager/scalar_data/redis_storage.py
@@ -70,10 +70,6 @@ def get_models(global_key: str, redis_connection: Redis):
 
             return cls(v)
 
-        @classmethod
-        def __modify_schema__(cls, field_schema):
-            field_schema.update(type="string", format="byte")
-
         def to_numpy(self) -> np.ndarray:
             return np.frombuffer(self.data.encode("latin-1"), dtype=np.float32)
 
@@ -204,7 +200,7 @@ class RedisCacheStorage(CacheStorage):
 
     def __init__(
             self,
-            global_key_prefix="gptcache",
+            global_key_prefix: str = "gptcache",
             host: str = "localhost",
             port: int = 6379,
             maxmemory: str = None,

--- a/tests/unit_tests/eviction/test_distributed_cache.py
+++ b/tests/unit_tests/eviction/test_distributed_cache.py
@@ -52,34 +52,6 @@ class TestDistributedCache(unittest.TestCase):
             self.assertEqual(manager.eviction_base.policy, "allkeys-lru")
             self.assertEqual(manager.eviction_base._ttl, None)
 
-    def test_lru_cache(self):
-        onnx = Onnx()
-        data_manager = manager_factory("redis,faiss",
-                                       eviction_manager="redis",
-                                       scalar_params={"url": self.url,
-                                                      "maxmemory": "1800kb",
-                                                      "policy": "allkeys-lru"
-                                                      },
-                                       vector_params={"dimension": onnx.dimension},
-                                       eviction_params=dict(url=self.url)
-                                       )
-        questions = []
-        answers = []
-        idx_list = []
-        for i in range(50):
-            idx_list.append(i)
-            questions.append(f'This is a question_{i}')
-            answers.append(f'This is an answer_{i}')
-
-        for idx, question, answer in zip(idx_list, questions, answers):
-            embedding = onnx.to_embeddings(question)
-            data_manager.save(
-                question=question,
-                answer=answer,
-                embedding_data=embedding
-            )
-
-        self.assertNotEquals(data_manager.s.count(), len(idx_list))
 
     def test_noeviction_policy(self):
         onnx = Onnx()

--- a/tests/unit_tests/eviction/test_distributed_cache.py
+++ b/tests/unit_tests/eviction/test_distributed_cache.py
@@ -31,7 +31,24 @@ class TestDistributedCache(unittest.TestCase):
                                                        maxmemory="100mb",
                                                        policy="allkeys-lru"))
         self.assertEqual(type(manager.eviction_base).__name__, "NoOpEviction")
+        self.assertEqual(manager.eviction_base.policy, "")
         self.assertEqual(type(manager.s).__name__, "RedisCacheStorage")
+
+    def test_eviction_base_str(self):
+        data_manager = get_data_manager(cache_base="sqlite",
+                                        vector_base=VectorBase("faiss", dimension=5),
+                                        eviction_base="redis"
+                                        )
+        self.assertIsNotNone(data_manager.eviction_base)
+        self.assertEqual(type(data_manager.eviction_base).__name__, "RedisCacheEviction")
+
+        data_manager = get_data_manager(cache_base="sqlite",
+                                        vector_base=VectorBase("faiss", dimension=5),
+                                        eviction_base="no_op_eviction"
+                                        )
+        self.assertIsNotNone(data_manager.eviction_base)
+        self.assertEqual(type(data_manager.eviction_base).__name__, "NoOpEviction")
+
 
     def test_redis_sqlite_cache_eviction(self):
         with TemporaryDirectory(dir="./") as root:
@@ -51,7 +68,6 @@ class TestDistributedCache(unittest.TestCase):
             self.assertEqual(type(manager.eviction_base).__name__, "RedisCacheEviction")
             self.assertEqual(manager.eviction_base.policy, "allkeys-lru")
             self.assertEqual(manager.eviction_base._ttl, None)
-
 
     def test_noeviction_policy(self):
         onnx = Onnx()

--- a/tests/unit_tests/eviction/test_distributed_cache.py
+++ b/tests/unit_tests/eviction/test_distributed_cache.py
@@ -57,7 +57,7 @@ class TestDistributedCache(unittest.TestCase):
         data_manager = manager_factory("redis,faiss",
                                        eviction_manager="redis",
                                        scalar_params={"url": self.url,
-                                                      "maxmemory": "2mb",
+                                                      "maxmemory": "1800kb",
                                                       "policy": "allkeys-lru"
                                                       },
                                        vector_params={"dimension": onnx.dimension},
@@ -66,7 +66,7 @@ class TestDistributedCache(unittest.TestCase):
         questions = []
         answers = []
         idx_list = []
-        for i in range(100):
+        for i in range(50):
             idx_list.append(i)
             questions.append(f'This is a question_{i}')
             answers.append(f'This is an answer_{i}')
@@ -78,13 +78,8 @@ class TestDistributedCache(unittest.TestCase):
                 answer=answer,
                 embedding_data=embedding
             )
-            for i in range(int(idx * 0.1)):
-                search_data = data_manager.search(embedding, top_k=1)
-                for res in search_data:
-                    data_manager.get_scalar_data(res)
 
         self.assertNotEquals(data_manager.s.count(), len(idx_list))
-        self.assertEqual(data_manager.get_scalar_data((0.0, 1)), None)
 
     def test_noeviction_policy(self):
         onnx = Onnx()

--- a/tests/unit_tests/eviction/test_distributed_cache.py
+++ b/tests/unit_tests/eviction/test_distributed_cache.py
@@ -1,0 +1,131 @@
+import time
+import unittest
+
+from redis_om import get_redis_connection
+
+from gptcache.embedding import Onnx
+from gptcache.manager import manager_factory
+
+
+class TestDistributedCache(unittest.TestCase):
+    url: str = "redis://default:default@localhost:6379"
+
+    def setUp(cls) -> None:
+        cls._clear_test_db()
+
+    @staticmethod
+    def _clear_test_db():
+        r = get_redis_connection(url=TestDistributedCache.url)
+        r.flushall()
+        r.flushdb()
+        time.sleep(1)
+
+    def test_redis_only_cache_eviction(self):
+        manager = manager_factory("redis,faiss",
+                                  eviction_manager="redis",
+                                  vector_params={"dimension": 5},
+                                  eviction_params=dict(url=self.url,
+                                                       maxmemory="100mb",
+                                                       policy="allkeys-lru"))
+        self.assertEqual(type(manager.eviction_base).__name__, "NoOpEviction")
+        self.assertEqual(type(manager.s).__name__, "RedisCacheStorage")
+
+    def test_redis_sqlite_cache_eviction(self):
+        manager = manager_factory("sqlite,faiss",
+                                  eviction_manager="redis",
+                                  vector_params={"dimension": 5},
+                                  eviction_params=dict(url=self.url,
+                                                       maxmemory="100mb",
+                                                       policy="allkeys-lru"))
+        self.assertEqual(type(manager.s).__name__, "SQLStorage")
+        self.assertEqual(type(manager.eviction_base).__name__, "RedisCacheEviction")
+        self.assertEqual(manager.eviction_base.policy, "allkeys-lru")
+        self.assertEqual(manager.eviction_base._ttl, None)
+
+    def test_lru_cache(self):
+        onnx = Onnx()
+        data_manager = manager_factory("redis,faiss",
+                                       eviction_manager="redis",
+                                       scalar_params={"url": self.url,
+                                                      "maxmemory": "2mb",
+                                                      "policy": "allkeys-lru"
+                                                      },
+                                       vector_params={"dimension": onnx.dimension},
+                                       eviction_params=dict(url=self.url)
+                                       )
+        questions = []
+        answers = []
+        idx_list = []
+        for i in range(100):
+            idx_list.append(i)
+            questions.append(f'This is a question_{i}')
+            answers.append(f'This is an answer_{i}')
+
+        for idx, question, answer in zip(idx_list, questions, answers):
+            embedding = onnx.to_embeddings(question)
+            data_manager.save(
+                question=question,
+                answer=answer,
+                embedding_data=embedding
+            )
+            for i in range(int(idx * 0.1)):
+                search_data = data_manager.search(embedding, top_k=1)
+                for res in search_data:
+                    data_manager.get_scalar_data(res)
+
+        self.assertNotEquals(data_manager.s.count(), len(idx_list))
+        self.assertEqual(data_manager.get_scalar_data((0.0, 1)), None)
+
+    def test_noeviction_policy(self):
+        onnx = Onnx()
+        data_manager = manager_factory("redis,faiss",
+                                       eviction_manager="redis",
+                                       scalar_params={"url": self.url
+                                                      },
+                                       vector_params={"dimension": onnx.dimension},
+                                       eviction_params={"maxmemory": "0",
+                                                        "policy": "noeviction"}
+                                       )
+        questions = []
+        answers = []
+        idx_list = []
+        for i in range(100):
+            idx_list.append(i)
+            questions.append(f'This is a question_{i}')
+            answers.append(f'This is an answer_{i}')
+
+        for idx, question, answer in zip(idx_list, questions, answers):
+            embedding = onnx.to_embeddings(question)
+            data_manager.save(
+                question=question,
+                answer=answer,
+                embedding_data=embedding
+            )
+
+        self.assertEqual(data_manager.s.count(), len(idx_list))
+
+    def test_ttl(self):
+        onnx = Onnx()
+        data_manager = manager_factory("redis,faiss",
+                                       eviction_manager="redis",
+                                       scalar_params={"url": self.url
+                                                      },
+                                       vector_params={"dimension": onnx.dimension},
+                                       eviction_params={"maxmemory": "0",
+                                                        "policy": "noeviction",
+                                                        "ttl": 1}
+                                       )
+        questions = []
+        answers = []
+        idx_list = []
+        embeddings = []
+        for i in range(10):
+            idx_list.append(i)
+            questions.append(f'This is a question_{i}')
+            answers.append(f'This is an answer_{i}')
+            embeddings.append(onnx.to_embeddings(questions[-1]))
+
+        data_manager.import_data(questions, answers, embedding_datas=embeddings,
+                                 session_ids=[None for _ in range(len(questions))])
+        time.sleep(5)
+        self.assertEqual(data_manager.s.count(), 0)


### PR DESCRIPTION
## Distributed Cache using Redis #496 
Feature for distributed cache. This allows us to store `keys` in Redis key-value store. 
Sorry, it took a while I spent too much time thinking about a design for this and how it will integrate into GPTCache's existing code base. 

I have also attached a high-level design of how Distributed Cache works. 

## Notes
A couple of notes about how the eviction will work based on different scalar storage configurations: 

Scenario 1: 
Scalar Storage is **MongoDB**,
Eviction Base is **Redis**.
Then the keys will be stored in Redis, and cache call back will update the TTL. 

Scenario 2: 
Scalar Storage is **Redis**,
Eviction Base is also **Redis**,
Then storing keys separately becomes redundant since Redis eviction is based on Memory usage rather than the number of keys.
Also, we'll be fetching values multiple times both while getting scalar data and while hitting cache callback, and it will add network overhead. 

To tackle this I created a NoOpEviction implementation (which skips cache operations) since, 
1. Redis internally manage the eviction based on memory size and eviction policy for all keys.  
2. We can configure RedisCacheStorage to update TTL upon creation and during access. This way values will be fetched from Redis only once. 

![GPT Distributed Cache](https://github.com/zilliztech/GPTCache/assets/4312730/a65c3e1b-adaf-4015-83b8-f3db02aae92c)
