### PR TITLE
feat: Add scalar storage support for DynamoDB 

### DIFF
--- a/.github/workflows/unit_test_main.yaml
+++ b/.github/workflows/unit_test_main.yaml
@@ -40,6 +40,11 @@ jobs:
         image: redis/redis-stack-server
         ports:
           - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:2.0.0
+        # rebinding to a different port since 8000 is a commonly used port
+        ports:
+          - 9999:8000
       mongo:
         image: mongo
         ports:

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ This module is created to extract embeddings from requests for similarity search
   - [x] Support [MariaDB](https://mariadb.org/).
   - [x] Support [SQL Server](https://www.microsoft.com/en-us/sql-server/).
   - [x] Support [Oracle](https://www.oracle.com/).
+  - [x] Support [DynamoDB](https://aws.amazon.com/dynamodb/).
   - [ ] Support [MongoDB](https://www.mongodb.com/).
   - [ ] Support [Redis](https://redis.io/).
   - [ ] Support [Minio](https://min.io/).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,7 +36,7 @@ def Milvus(**kwargs):
 2. Automatic installation
 ```python
 # 2.1 Add the import method
-# add new method to util/__init__.py
+# add new method to utils/__init__.py
 __all__ = ['import_pymilvus']
 
 from gptcache.utils.dependency_control import prompt_install

--- a/examples/README.md
+++ b/examples/README.md
@@ -250,6 +250,7 @@ Support general database
 - MariaDB.
 - SQL Server.
 - Oracle.
+- DynamoDB
 
 > [Example code](https://github.com/zilliztech/GPTCache/blob/main/examples/data_manager/scalar_store.py)
 

--- a/examples/data_manager/scalar_store.py
+++ b/examples/data_manager/scalar_store.py
@@ -22,6 +22,7 @@ def run():
         CacheBase('mariadb', sql_url='mariadb+pymysql://root:123456@127.0.0.1:3307/mysql'),
         CacheBase('sqlserver', sql_url='ssql+pyodbc://sa:Strongpsw_123@127.0.0.1:1434/msdb?driver=ODBC+Driver+17+for+SQL+Server'),
         CacheBase('oracle', sql_url='oracle+cx_oracle://oracle:123456@127.0.0.1:1521/?service_name=helowin&encoding=UTF-8&nencoding=UTF-8'),
+        CacheBase('dynamo'),
     ]
 
     for scalar_store in scalar_stores:

--- a/gptcache/manager/scalar_data/dynamo_storage.py
+++ b/gptcache/manager/scalar_data/dynamo_storage.py
@@ -1,0 +1,520 @@
+from functools import reduce
+from random import randint, SystemRandom
+from datetime import datetime
+from typing import List, Optional, Dict
+from decimal import Decimal
+from gptcache.manager.scalar_data.base import CacheStorage, CacheData, Question, QuestionDep, Answer
+from gptcache.utils import import_boto3
+from gptcache.utils.log import gptcache_log
+from concurrent.futures import ThreadPoolExecutor, wait
+import numpy as np
+import math
+
+import_boto3()
+from boto3.session import Session as AwsSession
+from boto3.dynamodb.conditions import Key as DynamoKey, Attr as DynamoAttr
+from boto3.dynamodb.types import Binary as DynamoBinary
+
+class DynamoStorage(CacheStorage):
+    """
+    DynamoDB storage using AWS's boto3 library.
+
+    :param aws_access_key_id: AWS access key ID. If not specified, boto3 will use the default resolution behavior.
+    :type host: str
+
+    :param aws_secret_access_key: AWS secret access key. If not specified, boto3 will use the default resolution behavior.
+    :type aws_secret_access_key str
+
+    :param aws_region_name: AWS region name. If not specified, boto3 will use the default resolution behavior.
+    :type aws_region_name: str
+
+    :param aws_profile_name: AWS profile name. If not specified, boto3 will use the default resolution behavior.
+    :type aws_profile_name: str
+
+    :param aws_endpoint_url: AWS endpoint URL. This is normally handled automatically but is exposed to allow overriding for testing purposes
+                            (using something like LocalStack or dynamoDB-local for example).
+    :type aws_endpoint_url: str
+    """
+
+    max_cardinality_suffix = 10
+
+    def __init__(
+        self,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
+        aws_region_name: str = None,
+        aws_profile_name: str = None,
+        aws_endpoint_url: str = None,
+    ):
+        self._aws_session = AwsSession(
+            aws_access_key_id = aws_access_key_id,
+            aws_secret_access_key = aws_secret_access_key,
+            region_name = aws_region_name,
+            profile_name = aws_profile_name,
+        )
+        self._dynamo = self._aws_session.resource(
+            "dynamodb",
+            endpoint_url=aws_endpoint_url,
+        )
+        self.create()
+
+    def create(self):
+        # NOTE: We use PAY_PER_REQUEST billing mode as per AWS's recommendations for unpredicatble workloads since it's
+        #       being used as a cache and so we won't know how many reads/writes we'll need to perform ahead of time.
+        recommended_billing_mode = "PAY_PER_REQUEST"
+
+        if not self._does_table_already_exist_and_is_active("gptcache_questions"):
+            self._dynamo.create_table(
+                TableName = "gptcache_questions",
+                KeySchema = [
+                    {"AttributeName": "pk", "KeyType": "HASH"},
+                    {"AttributeName": "id", "KeyType": "RANGE"},
+                ],
+                AttributeDefinitions = [
+                    {"AttributeName": "pk", "AttributeType": "S"},
+                    {"AttributeName": "id", "AttributeType": "S"},
+
+                    # You might be wondering why the 'deleted' attribute is a string value, not a BOOL.
+                    # This is because we need to efficiently be able to query items that are soft-deleted. This is normally
+                    # done with a GSI (GlobalSecondaryIndex). However, GSIs don't support the BOOL type due to low cardinality.
+                    # So we use a string instead.
+                    {"AttributeName": "deleted", "AttributeType": "S"},
+                ],
+                GlobalSecondaryIndexes = [
+                    {
+                        "IndexName": "gsi_items_by_type",
+                        "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    },
+                    {
+                        "IndexName": "gsi_questions_by_deletion_status",
+                        "KeySchema": [{"AttributeName": "deleted", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    },
+                ],
+                BillingMode = recommended_billing_mode,
+            )
+
+        if not self._does_table_already_exist_and_is_active("gptcache_reports"):
+            self._dynamo.create_table(
+                TableName = "gptcache_reports",
+                KeySchema = [
+                    {"AttributeName": "id", "KeyType": "HASH"},
+                ],
+                AttributeDefinitions = [
+                    {"AttributeName": "id", "AttributeType": "S"},
+                ],
+                BillingMode = recommended_billing_mode,
+            )
+
+    def batch_insert(self, all_data: List[CacheData]) -> List[str]:
+        """
+        Inserts a list of CacheData objects into the DynamoDB table and returns the ids of the inserted rows
+        """
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+        ids = []
+
+        with table.batch_writer() as batch:
+            for item in all_data:
+                item_deps = item.question.deps if isinstance(item.question, Question) and item.question.deps is not None else []
+                new_id_without_prefix = self._generate_id()
+                new_id = f"questions#{new_id_without_prefix}"
+                ids.append(new_id_without_prefix)
+                creation_time = item.create_on if item.create_on is not None else datetime.utcnow()
+
+                batch.put_item(
+                    Item = self._strip_all_props_with_none_values({
+                        "pk": new_id,
+                        "id": new_id,
+                        "question": self._question_text(item.question),
+                        "answers": [self._serialize_answer(answer) for answer in item.answers],
+                        "deps": [self._serialize_question_deps(dep) for dep in item_deps],
+                        #"session_id": item.session_id if item.session_id is not None else None,
+                        "create_on": creation_time.isoformat(timespec="microseconds"),
+                        "last_access": item.last_access.isoformat(timespec="microseconds") if item.last_access is not None else None,
+                        "embedding_data": DynamoBinary(item.embedding_data.tobytes()) if item.embedding_data is not None else None,
+                        "deleted": self._serialize_deleted_value(False),
+                    })
+                )
+
+                if item.session_id:
+                    batch.put_item(
+                        Item = self._strip_all_props_with_none_values({
+                            "pk": new_id,
+                            "id": f"sessions#{item.session_id}",
+                            "question": self._question_text(item.question),
+                        })
+                    )
+        return ids
+
+    def get_data_by_id(self, key: str) -> Optional[CacheData]:
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+
+        key_with_prefix = f"questions#{key}"
+
+        # get all sessions that contain this question
+        sessions_containing_question = table.query(
+            KeyConditionExpression = DynamoKey("pk").eq(key_with_prefix) & DynamoKey("id").begins_with("sessions#"),
+        )["Items"]
+
+        # then get the question info itself
+        response = table.get_item(
+            Key={"pk": key_with_prefix, "id": key_with_prefix},
+        )
+
+        if "Item" not in response or self._deserialize_deleted_value(response["Item"]["deleted"]):
+            return None
+
+        # after it's accessed, we need to update that particular item's last_access timestamp
+        table.update_item(
+            Key={"pk": key_with_prefix, "id": key_with_prefix},
+            UpdateExpression="SET last_access = :last_access",
+            ExpressionAttributeValues={
+                ":last_access": datetime.utcnow().isoformat(timespec="microseconds"),
+            },
+        )
+
+        cache_data = self._response_item_to_cache_data(response["Item"])
+        cache_data.session_id = [session["id"].split("#")[1] for session in sessions_containing_question]
+        return cache_data
+
+    def mark_deleted(self, keys: str):
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+
+        with table.batch_writer() as batch:
+            for key in keys:
+                batch.put_item(
+                    Item={
+                        "pk": f"questions#{key}",
+                        "id": f"questions#{key}",
+                        "deleted": self._serialize_deleted_value(True),
+                    }
+                )
+
+    def clear_deleted_data(self):
+        # Since the 'deleted' attribute is a string, we need to query for all items that have a 'deleted' value of
+        # 'True_*'. Then we can call delete on them.
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+
+        # Build out all possible values for the 'deleted' attribute and query it in 1 go. It cannot be done as one
+        # network call unfortunately due to limitations of DynamoDB. The DB only allows running queries on the GSI
+        # with a SINGLE, concrete value for the partition key.
+        #
+        # To address this, we're gonna spin up a thread pool and query concurrently
+        with ThreadPoolExecutor(max_workers = 10) as executor:
+            futures = []
+            for i in range(1, self.max_cardinality_suffix + 1):
+                futures.append(executor.submit(
+                    table.query,
+                    IndexName = "gsi_questions_by_deletion_status",
+                    KeyConditionExpression = DynamoKey("deleted").eq(f"True_{i}")
+                ))
+
+            completed_responses, incomplete_responses = wait(futures, timeout = 10)
+
+            if len(incomplete_responses) > 0:
+                gptcache_log.error(
+                    """
+                    Unable to complete deletion of all soft-deleted items due to request timeout.
+                    Some items may remain in the cache. %s",
+                    """,
+                    incomplete_responses,
+                )
+
+        soft_deleted_entries_per_partition = [response.result()["Items"] for response in completed_responses]
+        soft_deleted_entries = reduce(lambda x, y: x + y, soft_deleted_entries_per_partition)
+
+        keys = [entry["id"] for entry in soft_deleted_entries]
+
+        with table.batch_writer() as batch:
+            for key in keys:
+                batch.delete_item(
+                    Key={"pk": key, "id": key},
+                )
+
+    def get_ids(self, deleted: bool = True) -> List[str]:
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+
+        def run_scan_operation(last_evaluated_key):
+            filter_expression = (
+                DynamoAttr("id").begins_with("questions#") & DynamoAttr("deleted").begins_with(f"{deleted}_")
+            )
+
+            if last_evaluated_key is None:
+                return table.scan(
+                    Select = "SPECIFIC_ATTRIBUTES",
+                    ProjectionExpression = "pk",
+                    FilterExpression = filter_expression,
+                )
+            return table.scan(
+                Select = "SPECIFIC_ATTRIBUTES",
+                ProjectionExpression = "pk",
+                FilterExpression = filter_expression,
+                ExclusiveStartKey = last_evaluated_key,
+            )
+
+        all_responses = self._fetch_all_pages(run_scan_operation)
+        all_items = reduce(lambda x, y: x + y, [response["Items"] for response in all_responses])
+        all_ids = [int(item["pk"].replace("questions#", "")) for item in all_items]
+        return all_ids
+
+    def count(self, state: int = 0, is_all: bool = False) -> int:
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+        key_condition_expression = DynamoAttr("id").begins_with("questions#")
+
+        if not is_all and state == 0:
+            key_condition_expression &= DynamoAttr("deleted").begins_with("False_")
+        elif not is_all and state != 0:
+            key_condition_expression &= DynamoAttr("deleted").begins_with("True_")
+
+        # TODO: find out if specifying a "COUNT" select type results in a single page or not. For now, assume the worst
+        #       and attempt pagination anyway.
+        def run_scan_operation(last_evaluated_key):
+            if last_evaluated_key is None:
+                return table.scan(
+                    IndexName = "gsi_questions_by_deletion_status",
+                    FilterExpression = key_condition_expression,
+                    Select = "COUNT",
+                )
+
+            return table.scan(
+                IndexName = "gsi_questions_by_deletion_status",
+                FilterExpression = key_condition_expression,
+                ExclusiveStartKey = last_evaluated_key,
+                Select = "COUNT",
+            )
+
+        all_responses = self._fetch_all_pages(run_scan_operation)
+        return sum([response["Count"] for response in all_responses])
+
+    def add_session(self, question_id: str, session_id: str, session_question: str):
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+
+        table.put_item(
+            Item = {
+                "pk": f"questions#{question_id}",
+                "id": f"sessions#{session_id}",
+                "question": session_question,
+            },
+        )
+
+    def list_sessions(self, session_id = None, key = None) -> List[str]:
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+
+        if session_id and key:
+            response = table.query(
+                IndexName = "gsi_items_by_type",
+                ProjectionExpression = "id",
+                KeyConditionExpression = DynamoKey("id").eq(f"sessions#{session_id}"),
+                FilterExpression = DynamoAttr("pk").eq(f"questions#{key}"),
+            )
+        elif session_id:
+            response = table.query(
+                IndexName = "gsi_items_by_type",
+                ProjectionExpression = "id",
+                KeyConditionExpression = DynamoKey("id").eq(f"sessions#{session_id}"),
+            )
+        elif key:
+            response = table.query(
+                ProjectionExpression = "id",
+                KeyConditionExpression = DynamoKey("pk").eq(f"questions#{key}") & DynamoKey("id").begins_with("sessions#"),
+            )
+        else:
+            def run_scan_operation(last_evaluated_key):
+                filter_expression = DynamoAttr("id").begins_with("sessions#")
+
+                if last_evaluated_key is None:
+                    return table.scan(
+                        ProjectionExpression = "id",
+                        FilterExpression = filter_expression,
+                    )
+                return table.scan(
+                    ProjectionExpression = "id",
+                    FilterExpression = filter_expression,
+                    ExclusiveStartKey = last_evaluated_key,
+                )
+
+            response = self._fetch_all_pages(run_scan_operation)
+
+            # since these are paginated results, merge all items in each response to a new dict
+            response = reduce(lambda x, y: { "Items": x["Items"] + y["Items"] }, response)
+
+        # since sessions can be the shared across multiple items, we need to dedupe the results
+        return list({ item["id"].replace("questions#", "") for item in response["Items"] })
+
+    def delete_session(self, keys: List[str]):
+        table = self._dynamo.Table("gptcache_questions")
+        table.wait_until_exists()
+
+        # first find all items with that session_id
+        # unfortunately, there is no "batch get" operation on a GSI. So we need to spin up a thread pool and query
+        # concurrently
+        with ThreadPoolExecutor(max_workers = 10) as executor:
+            futures = []
+            for key in keys:
+                futures.append(executor.submit(
+                    table.query,
+                    IndexName = "gsi_items_by_type",
+                    Select = "SPECIFIC_ATTRIBUTES",
+                    ProjectionExpression = "pk, id",
+                    KeyConditionExpression = DynamoKey("id").eq(f"sessions#{key}")
+                ))
+
+            completed_responses, incomplete_responses = wait(futures, timeout = 10)
+
+            if len(incomplete_responses) > 0:
+                gptcache_log.error(
+                    "Unable to query all questions in session due to request timeout. %s",
+                    incomplete_responses,
+                )
+
+        items_per_session = [response.result()["Items"] for response in completed_responses]
+        all_relevant_items = reduce(lambda x, y: x + y, items_per_session)
+
+        # now we need to delete all items with those keys to clear out all session data.
+        with table.batch_writer() as batch:
+            for item in all_relevant_items:
+                batch.delete_item(
+                    Key={"pk": item["pk"], "id": item["id"]},
+                )
+
+    def report_cache(
+        self,
+        user_question,
+        cache_question,
+        cache_question_id,
+        cache_answer,
+        similarity_value,
+        cache_delta_time,
+    ):
+        table = self._dynamo.Table("gptcache_reports")
+        table.wait_until_exists()
+
+        table.put_item(
+            Item={
+                "id": str(self._generate_id()),
+                "user_question": user_question,
+                "cache_question": cache_question,
+                "cache_question_id": cache_question_id,
+                "cache_answer": cache_answer,
+                "similarity": (
+                    # DynamoDB doesn't support floats; only decimals
+                    Decimal(str(similarity_value))
+                    if isinstance(similarity_value, float)
+                    else similarity_value
+                ),
+                "cache_delta_time": Decimal(str(cache_delta_time)),
+            }
+        )
+
+    def close(self):
+        pass
+
+    def _does_table_already_exist_and_is_active(self, table_name: str) -> bool:
+        try:
+            self._dynamo.Table(table_name).table_status in ["ACTIVE", "UPDATING"]
+        except self._dynamo.meta.client.exceptions.ResourceNotFoundException:
+            return False
+        return True
+
+    def _wait_until_table_exists(self, table_name: str):
+        """
+        When tables are created in DynamoDB, they are not immediately available as table creation is asynchronous.
+        This function will block until the table is available in order to ensure we don't attempt to perform any
+        operations on a table that doesn't exist yet.
+        """
+        self._dynamo.Table(table_name).wait_until_exists()
+
+
+    def _response_item_to_cache_data(self, question_resp: Dict) -> Optional[CacheData]:
+        deps = question_resp["deps"] if "deps" in question_resp else []
+        return CacheData(
+            question = Question(
+                content = question_resp["question"],
+                deps = [self._deserialize_question_dep(dep) for dep in deps]
+            ),
+            answers = [self._deserialize_answer(answer) for answer in question_resp["answers"]],
+            embedding_data = np.frombuffer(question_resp["embedding_data"].value, dtype=np.float32),
+            create_on = datetime.fromisoformat(question_resp["create_on"]),
+            last_access = datetime.fromisoformat(question_resp["last_access"]) if "last_access" in question_resp else None,
+        )
+
+    def _fetch_all_pages(self, scan_fn) -> List[Dict]:
+        """
+        We often have to resort to scan operations in Dynamo which could result in a lot of data being returned. To ensure,
+        we get all the data, we need to paginate through the results. This function handles that for us.
+
+        :param scan_fn: The function to call to perform the scan operation. It must take in a last_evaluated_key to pass
+                        along to Dynamo and return a Dynamo response object
+
+        see: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/table/scan.html
+        """
+        all_responses = []
+        last_evaluated_key = None
+
+        while True:
+            response = scan_fn(last_evaluated_key)
+            all_responses.append(response)
+
+            if "LastEvaluatedKey" in response and len(response["LastEvaluatedKey"].keys()) > 0:
+                last_evaluated_key = response["LastEvaluatedKey"]
+            else:
+                break
+
+        return all_responses
+
+    def _question_text(self, question) -> str:
+        return question if isinstance(question, str) else question.content
+
+    def _generate_id(self):
+        """
+        Generates a unique ID for a row. Unfortunately, we cannot use something like uuid4() as scalar storage
+        implmentations need to return an integer based id.
+
+        It seems the underlying adapter that uses this class converts the ids to C longs which are 64-bit signed
+        so we'll use that as our upper bound.
+
+        We use systemrandom for better randomness.
+        """
+        return SystemRandom().randint(1, math.pow(2, 63) - 1)
+
+    def _strip_all_props_with_none_values(self, obj: Dict) -> Dict:
+        sanitized = {}
+        for k, v in obj.items():
+            if v is not None:
+                sanitized[k] = v
+        return sanitized
+
+    def _serialize_deleted_value(self, value: bool, suffix_value = randint(1, max_cardinality_suffix)) -> str:
+        """
+        We need to be able to query and filter on the 'deleted' attribute. However, in order for us to use this value
+        as an indexable value, it cannot be a BOOL (DynamoDB doesn't support it due to low cardinaility).
+
+        To increase the cardinality, we first convert the boolean to a string and append a random integer.
+
+        see: https://aws.amazon.com/blogs/database/how-to-design-amazon-dynamodb-global-secondary-indexes/
+        """
+        return f"{value}_{suffix_value}"
+
+    def _serialize_answer(self, answer: Answer) -> Dict:
+        return { "answer": answer.answer, "answer_type": answer.answer_type.value }
+
+    def _serialize_question_deps(self, dep: QuestionDep) -> Dict:
+        return { "name": dep.name, "data": dep.data, "dep_type": dep.dep_type.value }
+
+    def _deserialize_deleted_value(self, value: str) -> bool:
+        return value.startswith("True_")
+
+    def _deserialize_question_dep(self, dep: Dict) -> QuestionDep:
+        return QuestionDep(name = dep["name"], data = dep["data"], dep_type = int(dep["dep_type"]))
+
+    def _deserialize_answer(self, answer: Dict) -> Answer:
+        return Answer(answer = answer["answer"], answer_type = int(answer["answer_type"]))

--- a/gptcache/manager/scalar_data/manager.py
+++ b/gptcache/manager/scalar_data/manager.py
@@ -102,6 +102,16 @@ class CacheBase:
                 global_key_prefix=kwargs.pop("global_key_prefix", TABLE_NAME),
                 **kwargs
             )
+        elif name == "dynamo":
+            from gptcache.manager.scalar_data.dynamo_storage import DynamoStorage
+
+            return DynamoStorage(
+                aws_access_key_id=kwargs.get("aws_access_key_id"),
+                aws_secret_access_key=kwargs.get("aws_secret_access_key"),
+                aws_region_name=kwargs.get("region_name"),
+                aws_profile_name=kwargs.get("aws_profile_name"),
+                aws_endpoint_url=kwargs.get("endpoint_url"),
+            )
         else:
             raise NotFoundError("cache store", name)
         return cache_base

--- a/tests/unit_tests/manager/test_dynamo_storage.py
+++ b/tests/unit_tests/manager/test_dynamo_storage.py
@@ -1,0 +1,407 @@
+import numpy as np
+import pytest
+import unittest
+
+from random import randint
+from uuid import uuid4
+from datetime import datetime
+from decimal import Decimal
+from gptcache.manager.scalar_data.base import CacheStorage, CacheData, DataType, Question, QuestionDep
+from gptcache.utils import import_boto3
+from gptcache.manager.scalar_data.dynamo_storage import DynamoStorage 
+
+import_boto3()
+
+from boto3.dynamodb.conditions import Attr as DynamoAttr, Key as DynamoKey
+from boto3 import client as awsclient, resource as awsresource
+import boto3
+
+class TestDynamoCacheStorage(unittest.TestCase):
+    _dynamodb_local_endpoint_url = "http://localhost:9999"
+    _region_name = "us-east-1"
+
+    def setUp(self):
+        # First find all the tables and blow them away to keep a clean slate before starting tests
+        dynamo_client = awsclient(
+            "dynamodb",
+            endpoint_url = self._dynamodb_local_endpoint_url,
+            aws_access_key_id = "test",
+            aws_secret_access_key = "test",
+            region_name = self._region_name,
+        )
+        table_names = dynamo_client.list_tables()["TableNames"]
+
+        for table_name in table_names:
+            dynamo_client.delete_table(TableName=table_name)
+
+        self.dynamo_cache_storage = DynamoStorage(
+            aws_endpoint_url = self._dynamodb_local_endpoint_url,
+            aws_access_key_id = "test",
+            aws_secret_access_key = "test",
+            aws_region_name = self._region_name,
+        )
+
+    def test_create_is_idempotent(self):
+        try:
+            self.dynamo_cache_storage.create()
+            self.dynamo_cache_storage.create()
+            self.dynamo_cache_storage.create()
+            self.dynamo_cache_storage.create()
+        except Exception as e:
+            pytest.fail("create() method should be idempotent. It failed with exception: " + str(e))
+
+        # now manually query via boto3 to make sure the table is there
+        table = self._dynamo_resource().Table("gptcache_questions")
+        assert table is not None
+
+        table = self._dynamo_resource().Table("gptcache_reports")
+        assert table is not None
+
+    def test_creation_and_batch_insert(self):
+        time_before_insertion = datetime.utcnow()
+        cache_entries_to_insert = [
+            self._random_cachedata_without_dependencies(session_id = "1"),
+            self._random_cachedata_without_dependencies(),
+            self._random_cachedata_with_dependencies(session_id = "3"),
+        ]
+        self.dynamo_cache_storage.batch_insert(cache_entries_to_insert)
+
+        # now manually query via boto3 to make sure the data is there
+        table = self._dynamo_resource().Table("gptcache_questions")
+        items = table.scan()['Items']
+
+        # Since there are session_ids for each item except one, there should be a corresponding session entries in this
+        # table. So there should be (3 regular question rows + 2 session rows) = 5 items in the table.
+        assert len(items) == 5
+
+        for item in items:
+            original_data_inserted = next(
+                    (cache_data for cache_data in cache_entries_to_insert if (cache_data.question == item["question"] or 
+                        isinstance(cache_data.question, Question) and cache_data.question.content == item["question"])),
+                    None
+            )
+            expected_question_text = (
+                original_data_inserted.question
+                if isinstance(original_data_inserted.question, str)
+                else original_data_inserted.question.content
+            )
+
+            if item["id"].startswith("sessions#"):
+                assert original_data_inserted.session_id == item["id"].split("#")[1]
+                assert expected_question_text == item["question"]
+
+            else:
+                assert expected_question_text == item["question"]
+
+                # ensure that a 'create_on' timestamp is always set for new items.
+                assert (datetime.fromisoformat(item["create_on"]) > time_before_insertion and 
+                        datetime.fromisoformat(item["create_on"]) < datetime.utcnow())
+
+                # The last access value should be blank because the entry is new and nothing has accessed it yet.
+                assert "last_access" not in item 
+
+                # It shouldn't be deleted. Since boolean values have low cardinality, the class should be suffixing the value
+                # with a random integer to avoid hot partitions as per AWS's recommendations.
+                assert item["deleted"].startswith("False_")
+
+                assert (original_data_inserted.embedding_data == np.frombuffer(item["embedding_data"].value, dtype=np.float32)).all()
+
+                # if the question has dependencies, make sure they're all there
+                if isinstance(original_data_inserted.question, Question) and original_data_inserted.question.deps is not None:
+                    assert len(original_data_inserted.question.deps) == len(item["deps"])
+                    for dep in original_data_inserted.question.deps:
+                        matching_cache_entry = next(
+                                (dep_dict for dep_dict in item["deps"] if dep.name == dep_dict["name"]),
+                                None
+                        )
+                        assert matching_cache_entry is not None
+                        assert matching_cache_entry["data"] == dep.data
+                        assert matching_cache_entry["dep_type"] == dep.dep_type
+
+                for answer in original_data_inserted.answers:
+                    matching_cache_entry = next((answer_dict for answer_dict in item["answers"] if answer.answer == answer_dict["answer"]), None)
+                    assert matching_cache_entry is not None
+                    assert matching_cache_entry["answer_type"] == answer.answer_type
+
+    def test_mark_deleted(self):
+        item_to_insert = self._random_cachedata_without_dependencies(session_id = "1")
+        persisted_id = self.dynamo_cache_storage.batch_insert([item_to_insert])[0]
+
+        # now mark it as deleted
+        self.dynamo_cache_storage.mark_deleted([persisted_id])
+
+        # it should have been soft deleted. Boto3 API shouldn't even return an "Item" obj in the response if its deleted
+        table = self._dynamo_resource().Table("gptcache_questions")
+        resp = table.get_item(
+            Key={"pk": f"questions#{persisted_id}", "id": f"questions#{persisted_id}"},
+        )
+        assert resp["Item"]["deleted"].startswith("True_")
+
+    def test_clear_deleted_data(self):
+        # first let's insert some data, mark them as deleted
+        items_to_insert = [
+            self._random_cachedata_without_dependencies(session_id = "1"),
+            self._random_cachedata_without_dependencies(),
+            self._random_cachedata_without_dependencies(),
+        ]
+        persisted_ids = self.dynamo_cache_storage.batch_insert(items_to_insert)
+
+        # only delete the first 2 (just to ensure we can later assert the method in test doesn't actually 
+        # delete ALL data from the table)
+        self.dynamo_cache_storage.mark_deleted(persisted_ids[:2])
+
+        # now clear the deleted data. This should remove it completely from the table (aka. hard delete)
+        self.dynamo_cache_storage.clear_deleted_data()
+
+        # now query the table and make sure the first 2 items are gone, but the last one is still there
+        table = self._dynamo_resource().Table("gptcache_questions")
+        resp = table.scan(FilterExpression = DynamoAttr("id").begins_with("questions#"))
+
+        assert len(resp["Items"]) == 1
+        assert int(resp["Items"][0]["id"].replace("questions#", "")) == persisted_ids[2]
+
+    def test_get_ids(self):
+        # first let's insert some data, mark them as deleted
+        items_to_insert = [
+            self._random_cachedata_without_dependencies(session_id = "1"),
+            self._random_cachedata_without_dependencies(),
+            self._random_cachedata_without_dependencies(),
+        ]
+        persisted_ids = self.dynamo_cache_storage.batch_insert(items_to_insert)
+
+        # only delete the first 2 (just to ensure we can later assert the method in test doesn't actually 
+        # delete ALL data from the table)
+        self.dynamo_cache_storage.mark_deleted(persisted_ids[:2])
+
+        # by default, the get_ids method should return only deleted ids. all ids, including deleted ones
+        deleted_ids = self.dynamo_cache_storage.get_ids()
+        assert sorted(deleted_ids) == sorted(persisted_ids[:2])
+
+        # now if we pass in deleted = True, it should, again, only return the deleted ids
+        deleted_ids = self.dynamo_cache_storage.get_ids(deleted = True)
+        assert sorted(deleted_ids) == sorted(persisted_ids[:2])
+
+        # now if we pass in deleted = False, it should return the undeleted items 
+        undeleted_ids = self.dynamo_cache_storage.get_ids(deleted = False)
+        assert sorted(undeleted_ids) == sorted([persisted_ids[2]])
+
+
+    def test_count(self):
+        # first let's insert some data, mark them as deleted
+        items_to_insert = [
+            self._random_cachedata_without_dependencies(session_id = "1"),
+            self._random_cachedata_without_dependencies(session_id = "1"),
+            self._random_cachedata_without_dependencies(),
+        ]
+        persisted_ids = self.dynamo_cache_storage.batch_insert(items_to_insert)
+
+        # delete one of the items
+        self.dynamo_cache_storage.mark_deleted([persisted_ids[0]])
+
+        # by default, it retuns only the undeleted ids
+        assert self.dynamo_cache_storage.count() == 2
+
+        # now if we pass in state = 0, it should only return the undeleted ids
+        # Doing the opposite will return only deleted ids.
+        assert self.dynamo_cache_storage.count(state = 0) == 2
+        assert self.dynamo_cache_storage.count(state = -1) == 1
+
+        assert self.dynamo_cache_storage.count(is_all = True) == 3
+
+    def test_add_session(self):
+        item_to_insert = self._random_cachedata_with_dependencies()
+        persisted_id = self.dynamo_cache_storage.batch_insert([item_to_insert])[0]
+
+        # now add a question to some sessions 
+        session_id1 = str(uuid4())
+        session_id2 = str(uuid4())
+        self.dynamo_cache_storage.add_session(persisted_id, session_id1, item_to_insert.question.content)
+        self.dynamo_cache_storage.add_session(persisted_id, session_id2, item_to_insert.question.content)
+
+        # now query the table and make sure the sessions are there
+        table = self._dynamo_resource().Table("gptcache_questions")
+        session1_questions = table.query(
+            IndexName = "gsi_items_by_type",
+            KeyConditionExpression = DynamoKey("id").eq(f"sessions#{session_id1}")
+        )["Items"]
+        session2_questions = table.query(
+            IndexName = "gsi_items_by_type",
+            KeyConditionExpression = (DynamoKey("id").eq(f"sessions#{session_id2}"))
+        )["Items"]
+
+        assert len(session1_questions) == 1
+        assert session1_questions[0]["question"] == item_to_insert.question.content
+        assert int(session1_questions[0]["pk"].replace("questions#", "")) == persisted_id
+
+        assert len(session2_questions) == 1
+        assert session2_questions[0]["question"] == item_to_insert.question.content
+        assert int(session2_questions[0]["pk"].replace("questions#", "")) == persisted_id
+
+    def test_list_sessions(self):
+        items_to_insert = [
+            self._random_cachedata_with_dependencies(),
+            self._random_cachedata_with_dependencies(),
+        ]
+        persisted_ids = self.dynamo_cache_storage.batch_insert(items_to_insert)
+
+        # now add a question to some sessions 
+        session_id1 = str(uuid4())
+        session_id2 = str(uuid4())
+        session_id3 = str(uuid4())
+        self.dynamo_cache_storage.add_session(persisted_ids[0], session_id1, items_to_insert[0].question.content)
+        self.dynamo_cache_storage.add_session(persisted_ids[0], session_id2, items_to_insert[0].question.content)
+        self.dynamo_cache_storage.add_session(persisted_ids[1], session_id3, items_to_insert[1].question.content)
+
+        ids_without_prefix = lambda ids: [id_with_prefix.replace("sessions#", "") for id_with_prefix in ids]
+
+        # now we should be able to see those sessions
+        session_ids_with_prefix = self.dynamo_cache_storage.list_sessions()
+        assert sorted(ids_without_prefix(session_ids_with_prefix)) == sorted([session_id1, session_id2, session_id3])
+
+        # now filter by one of the session ids
+        session_ids_with_prefix = self.dynamo_cache_storage.list_sessions(session_id = session_id1)
+        assert ids_without_prefix(session_ids_with_prefix) == [session_id1]
+
+        # now filter by the question id
+        session_ids_with_prefix = self.dynamo_cache_storage.list_sessions(key = persisted_ids[1])
+        assert sorted(ids_without_prefix(session_ids_with_prefix)) == sorted([session_id3])
+
+        # now filter by both
+        session_ids_with_prefix = self.dynamo_cache_storage.list_sessions(session_id = session_id2, key = persisted_ids[0])
+        assert ids_without_prefix(session_ids_with_prefix) == [session_id2]
+
+    def test_delete_session(self):
+        session_id1 = str(uuid4())
+        session_id2 = str(uuid4())
+        items_to_insert = [
+            self._random_cachedata_with_dependencies(session_id = session_id1),
+            self._random_cachedata_with_dependencies(session_id = session_id1),
+            self._random_cachedata_with_dependencies(session_id = session_id2),
+            self._random_cachedata_with_dependencies(),
+        ]
+        persisted_ids = self.dynamo_cache_storage.batch_insert(items_to_insert)
+
+        # now delete the session
+        self.dynamo_cache_storage.delete_session([session_id1])
+
+        # There shouldn't be a session entry for session_id1 anymore but the other sessions should still exist.
+        session_ids_with_prefix = self.dynamo_cache_storage.list_sessions()
+        assert session_ids_with_prefix == [f"sessions#{session_id2}"]
+
+
+    def test_get_data_by_id(self):
+        time_before_insertion = datetime.utcnow()
+
+        item_to_insert = self._random_cachedata_with_dependencies(session_id = "1")
+        persisted_id = self.dynamo_cache_storage.batch_insert([item_to_insert])[0]
+
+        entry = self.dynamo_cache_storage.get_data_by_id(persisted_id)
+        assert entry.question.content == item_to_insert.question.content
+        assert entry.session_id == [item_to_insert.session_id]
+        assert (entry.embedding_data == item_to_insert.embedding_data).all()
+        assert entry.create_on > time_before_insertion
+
+        for answer in entry.answers:
+            matching_answer = next(
+                (answer_to_insert for answer_to_insert in item_to_insert.answers if answer.answer == answer_to_insert.answer and answer.answer_type == answer_to_insert.answer_type),
+                None
+            )
+            assert matching_answer is not None
+
+        # The first time you access it, the last_access should be None (since we're accessing it for the first time)
+        assert entry.last_access is None
+
+        # ensure that each time we access it, the last_access value is updated
+        entry_accessed_again = self.dynamo_cache_storage.get_data_by_id(persisted_id)
+        entry_accessed_again.last_access > time_before_insertion
+
+        entry_accessed_thrice = self.dynamo_cache_storage.get_data_by_id(persisted_id)
+        entry_accessed_thrice.last_access > entry_accessed_again.last_access
+
+        # next test with a random id that doesn't exist. It should return None
+        entry = self.dynamo_cache_storage.get_data_by_id(str(uuid4()))
+        assert entry is None
+
+        # now soft delete the existing row in dynamo and make sure it's not returned
+        table = self._dynamo_resource().Table("gptcache_questions")
+        table.update_item(
+            Key = {
+                "pk": f"questions#{persisted_id}",
+                "id": f"questions#{persisted_id}",
+            },
+            UpdateExpression = "SET deleted = :deleted",
+            ExpressionAttributeValues = {
+                ":deleted": "True_1"
+            }
+        )
+
+        entry = self.dynamo_cache_storage.get_data_by_id(persisted_id)
+        assert entry is None
+
+    def test_report_cache(self):
+        item_to_insert = {
+            "user_question": "how many people in this picture?",
+            "cache_question": "how many people are in this picture?",
+            "cache_question_id": f"questions#{str(uuid4())}",
+            "cache_answer": "5",
+            "similarity_value": 0.9,
+            "cache_delta_time": 0.5,
+        }
+
+        self.dynamo_cache_storage.report_cache(
+            user_question = item_to_insert["user_question"],
+            cache_question = item_to_insert["cache_question"],
+            cache_question_id = item_to_insert["cache_question_id"],
+            cache_answer = item_to_insert["cache_answer"],
+            similarity_value = item_to_insert["similarity_value"],
+            cache_delta_time = item_to_insert["cache_delta_time"],
+        )
+
+        # now manually query via boto3 to make sure the data is there
+        table = self._dynamo_resource().Table("gptcache_reports")
+        items = table.scan()['Items']
+
+        # Since there are session_ids for each item except one, there should be a corresponding session entries in this
+        # table. So there should be (3 regular question rows + 2 session rows) = 5 items in the table.
+        assert len(items) == 1
+
+        assert items[0]["user_question"] == item_to_insert["user_question"]
+        assert items[0]["cache_question"] == item_to_insert["cache_question"]
+        assert items[0]["cache_question_id"] == item_to_insert["cache_question_id"]
+        assert items[0]["cache_answer"] == item_to_insert["cache_answer"]
+        assert items[0]["similarity"] == Decimal(str(item_to_insert["similarity_value"]))
+        assert items[0]["cache_delta_time"] == Decimal(str(item_to_insert["cache_delta_time"]))
+
+    def _random_cachedata_without_dependencies(self, session_id = None):
+        question_id = uuid4()
+        return CacheData(
+            question = f"question_{question_id}",
+            answers = [f"answer1_for_{question_id}", f"answer2_for_{question_id}"],
+            embedding_data = np.random.rand(8).astype(np.float32),
+            session_id = session_id,
+        )
+
+    def _random_cachedata_with_dependencies(self, session_id = None):
+        question_id = uuid4()
+        return CacheData(
+            question = Question(
+                content = f"question_{question_id}",
+                deps = [
+                    QuestionDep(name = "text", data = "how many people in this picture", dep_type = DataType.STR),
+                    QuestionDep(name = "image", data = "object_name", dep_type = DataType.IMAGE_BASE64),
+                ],
+            ),
+            answers = [f"answer1_for_{question_id}"],
+            embedding_data = np.random.rand(8).astype(np.float32),
+            session_id = session_id,
+        )
+
+    def _dynamo_resource(self):
+        return awsresource(
+            "dynamodb",
+            endpoint_url = self._dynamodb_local_endpoint_url,
+            aws_access_key_id = "test",
+            aws_secret_access_key = "test",
+            region_name = self._region_name,
+        )
+


### PR DESCRIPTION
This change allows GPTCache to use DynamoDB as the underlying scalar
storage for the cache. Addresses #200 

The underlying implementation uses 2 tables:

- `gptcache_questions` - which holds all questions and session
  information.
- `gptcache_reports` - which holds the reporting information.

Normally, we would do a single table design and rollup
`gptcache_reports` into the same table as `gptcache_questions`. However,
this was not done for one key reason: billing.

In the event a lot of analytics data is being created, then table scans
for operations like `count()` and `get_ids()` would also involve reading
these reporting rows before filtering them out, resulting in higher
read costs for end users of GPTCache.


## Preview of what the tables look like:

#### `gpt_cache` table

<img width="1128" alt="image" src="https://github.com/zilliztech/GPTCache/assets/5430280/8bd96d6a-4ad5-4559-a38c-7f5b6fe4dd5f">

#### Secondary Indexes:

**gsi_items_by_type:**

<img width="1125" alt="image" src="https://github.com/zilliztech/GPTCache/assets/5430280/bd59b907-3c73-42d3-a445-57d1b19dbf3d">

**gsi_questions_by_deletion_status**:
<img width="1130" alt="image" src="https://github.com/zilliztech/GPTCache/assets/5430280/6fa16cce-d39c-4b86-aa7f-9e5fc60accdb">
