### PR TITLE
bugfix: fix correct dependency name for redis-om

### DIFF
--- a/gptcache/utils/__init__.py
+++ b/gptcache/utils/__init__.py
@@ -267,4 +267,3 @@ def import_starlette():
 
 def import_weaviate():
     _check_library("weaviate-client")
-B

--- a/gptcache/utils/__init__.py
+++ b/gptcache/utils/__init__.py
@@ -258,7 +258,7 @@ def import_fastapi():
 
 def import_redis():
     _check_library("redis")
-    _check_library("redis-om")
+    _check_library("redis_om", package="redis-om")
 
 
 def import_starlette():
@@ -267,3 +267,4 @@ def import_starlette():
 
 def import_weaviate():
     _check_library("weaviate-client")
+B

--- a/gptcache/utils/__init__.py
+++ b/gptcache/utils/__init__.py
@@ -258,7 +258,7 @@ def import_fastapi():
 
 def import_redis():
     _check_library("redis")
-    _check_library("redis_om")
+    _check_library("redis-om")
 
 
 def import_starlette():


### PR DESCRIPTION
 library name is wrong for redis_om, instead it should be redis-om