### PR TITLE
Fix metaclass conflict error when installing pydantic v2 and using langchain

### DIFF
--- a/gptcache/adapter/langchain_models.py
+++ b/gptcache/adapter/langchain_models.py
@@ -4,13 +4,11 @@ from gptcache.adapter.adapter import adapt, aadapt
 from gptcache.core import cache
 from gptcache.manager.scalar_data.base import Answer, DataType
 from gptcache.session import Session
-from gptcache.utils import import_pydantic, import_langchain
+from gptcache.utils import import_langchain
 
-import_pydantic()
 import_langchain()
 
 # pylint: disable=C0413
-from pydantic import BaseModel
 from langchain.llms.base import LLM
 from langchain.chat_models.base import BaseChatModel
 from langchain.schema import (
@@ -27,7 +25,7 @@ from langchain.callbacks.manager import (
 
 
 # pylint: disable=protected-access
-class LangChainLLMs(LLM, BaseModel):
+class LangChainLLMs(LLM):
     """LangChain LLM Wrapper.
 
     :param llm: LLM from langchain.llms.
@@ -127,7 +125,7 @@ class LangChainLLMs(LLM, BaseModel):
 
 
 # pylint: disable=protected-access
-class LangChainChat(BaseChatModel, BaseModel):
+class LangChainChat(BaseChatModel):
     """LangChain LLM Wrapper.
 
     :param chat: LLM from langchain.chat_models.

--- a/tests/unit_tests/adapter/test_langchain_models.py
+++ b/tests/unit_tests/adapter/test_langchain_models.py
@@ -8,10 +8,9 @@ from gptcache.adapter import openai
 from gptcache.adapter.api import init_similar_cache, get
 from gptcache.adapter.langchain_models import LangChainLLMs, LangChainChat, _cache_msg_data_convert
 from gptcache.processor.pre import get_prompt, last_content_without_template, get_messages_last_content
-from gptcache.utils import import_pydantic, import_langchain
+from gptcache.utils import import_langchain
 from gptcache.utils.response import get_message_from_openai_answer
 
-import_pydantic()
 import_langchain()
 
 from langchain import OpenAI, PromptTemplate

--- a/tests/unit_tests/embedding/test_langchain.py
+++ b/tests/unit_tests/embedding/test_langchain.py
@@ -2,7 +2,6 @@ from gptcache.embedding import LangChain
 from gptcache.utils import import_langchain, prompt_install
 
 import_langchain()
-prompt_install("pydantic==1.10.8")
 from langchain.embeddings import FakeEmbeddings
 
 


### PR DESCRIPTION
/kind improvement
Fix metaclass conflict error when installing pydantic v2 and using langchain
thanks @yacchi 