### PR TITLE
    Update weaviate installation to check for weaviate pkg instead of…

### DIFF
--- a/gptcache/utils/__init__.py
+++ b/gptcache/utils/__init__.py
@@ -266,4 +266,4 @@ def import_starlette():
 
 
 def import_weaviate():
-    _check_library("weaviate-client")
+    _check_library("weaviate", package="weaviate-client")


### PR DESCRIPTION
weaviate-client won't be found by importlib.util.find_spec, should be searching for weaviate to check dependency installation instead

Signed-off-by: Amrit Singh <amrit2@cisco.com>