### PR TITLE
Updated embedding to work with OpenAI's Python v1.3+ and with Azure O…

### DIFF
--- a/gptcache/embedding/__init__.py
+++ b/gptcache/embedding/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
 from gptcache.utils.lazy_import import LazyImport
 
 openai = LazyImport("openai", globals(), "gptcache.embedding.openai")
+azureopenai = LazyImport("azureopenai", globals(), "gptcache.embedding.azureopenai")
 huggingface = LazyImport("huggingface", globals(), "gptcache.embedding.huggingface")
 sbert = LazyImport("sbert", globals(), "gptcache.embedding.sbert")
 onnx = LazyImport("onnx", globals(), "gptcache.embedding.onnx")
@@ -37,7 +38,7 @@ def Cohere(model="large", api_key=None):
 
 
 def OpenAI(model="text-embedding-ada-002", api_key=None):
-    return openai.OpenAI(model, api_key)
+    return openai.OpenAIEmbedding(model, api_key)
 
 
 def Huggingface(model="distilbert-base-uncased"):

--- a/gptcache/embedding/azureopenai.py
+++ b/gptcache/embedding/azureopenai.py
@@ -1,0 +1,82 @@
+from typing import Union
+
+import numpy as np
+
+from gptcache.embedding.base import BaseEmbedding
+from gptcache.utils import import_openai
+
+import_openai()
+
+from openai.lib.azure import AzureOpenAI, AsyncAzureOpenAI
+
+
+class AzureOpenAIEmbedding(BaseEmbedding):
+    """Generate text embedding for given text using Azure's OpenAI service.
+
+    :param model: OpenAI Client with any modifications you intend to use.
+    :type model: str
+
+    :param model: model id from the API, defaults to 'text-embedding-ada-002'.
+    :type model: str
+
+    Example:
+        .. code-block:: python
+
+            from gptcache.embedding import AzureOpenAIEmbedding
+            from openai import AzureOpenAI
+
+            test_sentence = 'Hello, world.'
+            client = AzureOpenAI()
+
+            # You can create different deployments for different embedding models on Azure.
+            encoder = OpenAIEmbedding(client, azure_deployment='my_embedding_azure_deployment')
+
+            embed = encoder.to_embeddings(test_sentence)
+    """
+
+    def __init__(self,
+                 client: Union[AzureOpenAI, AsyncAzureOpenAI],
+                 azure_deployment: str,
+                 model: str = 'text-embedding-ada-002',
+                 ):
+        """
+
+        :param client: Azure OpenAI Client class
+        :type client: Union[AzureOpenAI, AsyncAzureOpenAI]
+        :param azure_deployment: The deployment name for the embedding; used to generate the endpoint url.
+        :type azure_deployment: str
+        :param model: The name of the embedding model; only used for determining the dimensions.  Defaults to "text-embedding-ada-002"
+        :type model: str
+        """
+        self.model = model
+        self.__azure_embedding_model_deployment = azure_deployment
+        self.__dimension = self.dim_dict().get(self.model, None)
+        self.client = client
+
+    def to_embeddings(self, data, **_):
+        """
+
+        :param data: String that you wish to convert to an embedding.
+        :param _:
+        :return: Array of Float32 numbers that represent the string
+        """
+        sentence_embeddings = await self.client.embeddings.create(
+            input=data,
+            model=self.__azure_embedding_model_deployment,
+        )
+        return np.array(sentence_embeddings.data[0].embedding).astype("float32")
+
+    @property
+    def dimension(self):
+        """Embedding dimension.
+
+        :return: embedding dimension
+        """
+        if not self.__dimension:
+            foo_emb = self.to_embeddings("foo")
+            self.__dimension = len(foo_emb)
+        return self.__dimension
+
+    @staticmethod
+    def dim_dict():
+        return {"text-embedding-ada-002": 1536}


### PR DESCRIPTION
Hi!

This is meant to correct problems with embedding in the latest versions of the OpenAI Python Library and GPTCache.

The latest versions of the OpenAI Python API do not include the `.api_base` function; even if you manually override it, this leads to other issues.  Moreover, the best practice now is to instantiate a client and to use it instead of the global context.

The Azure OpenAI part has further complications related to "Azure Deployments" and different os.environ variables.

Rather than keep track of these within GPTCache, my suggestion is that it might make sense to have the user pass in an instance of the OpenAI client object.

I have access to both OpenAI and Azure OpenAI so I can offer additional help with that if necessary.