### PR TITLE
Fixed the wrong similarity_threshold documentation

### DIFF
--- a/gptcache/config.py
+++ b/gptcache/config.py
@@ -9,7 +9,7 @@ class Config:
     :param log_time_func: optional, customized log time function
     :type log_time_func: Optional[Callable[[str, float], None]]
     :param similarity_threshold: a threshold ranged from 0 to 1 to filter search results with similarity score higher \
-     than the threshold. When it is 0, there is no hits. When it is 1, all search results will be returned as hits.
+     than the threshold. When it is 0, all search results will be returned as hits. When it is 1, there is no hits.
     :type similarity_threshold: float
     :param prompts: optional, if the request content will remove the prompt string when the request contains the prompt list
     :type prompts: Optional[List[str]]


### PR DESCRIPTION
Signed-off-by: sahusiddharth

fixes: #578 

The documentation incorrectly states that when `similarity_threshold` is set to 1, all search results will be returned as hits. However, in practice, with `similarity_threshold=1` does not yield any hits.

Describe the Changes Made:

- Updated the documentation to accurately reflect the behavior of `similarity_threshold`.
- Removed the misleading information about setting `similarity_threshold` to 1 resulting in all search results being returned as hits.