### PR TITLE
Fix last_content_without_template

### DIFF
--- a/gptcache/processor/pre.py
+++ b/gptcache/processor/pre.py
@@ -60,7 +60,7 @@ def _get_pattern_value(pattern_str: str, value_str: str):
 
     pattern_values = {}
     last_end = 0
-    for i, literal_text in enumerate(literal_text_arr):
+    for i, (literal_text, field_name) in enumerate(zip(literal_text_arr, field_name_arr)):
         start = value_str.find(literal_text, last_end)
         if i == len(literal_text_arr) - 1:
             end = len(value_str)
@@ -69,7 +69,7 @@ def _get_pattern_value(pattern_str: str, value_str: str):
         if start == -1 or end == -1:
             break
         start += len(literal_text)
-        pattern_values[field_name_arr[i]] = value_str[start:end]
+        pattern_values[field_name] = value_str[start:end]
         last_end = end
     return pattern_values
 


### PR DESCRIPTION
Fix last_content_without_template when the template looks like "Tell me a joke about {subject} with less than 50 words." where len(field_name_arr) < len(literal_text_arr).
Existing implementation error out like the following:
```
Traceback (most recent call last):
  File "/Users/zz/src/GPTCache/sbert_match.py", line 62, in <module>
    response = openai.ChatCompletion.create(
  File "/Users/zz/src/GPTCache/gptcache/adapter/openai.py", line 125, in create
    return adapt(
  File "/Users/zz/src/GPTCache/gptcache/adapter/adapter.py", line 55, in adapt
    pre_embedding_res = time_cal(
  File "/Users/zz/src/GPTCache/gptcache/utils/time.py", line 9, in inner
    res = func(*args, **kwargs)
  File "/Users/zz/src/GPTCache/gptcache/processor/pre.py", line 134, in last_content_without_template
    pattern_value = _get_pattern_value(cache_config.template, last_content_str)
  File "/Users/zz/src/GPTCache/gptcache/processor/pre.py", line 72, in _get_pattern_value
    pattern_values[field_name_arr[i]] = value_str[start:end]
IndexError: list index out of range
```