### PR TITLE
Add Nomic embedding integration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -150,6 +150,20 @@ paddlenlp = PaddleNLP()
 
 </details>
 
+<details>
+
+<summary> Nomic </summary>
+
+```python
+from gptcache.embedding import Nomic
+
+nm = Nomic(api_key='your-api-key')
+# nm.dimension
+# nm.to_embeddings
+```
+
+</details>
+
 ### Custom embedding
 
 The function has two parameters: the preprocessed string and parameters reserved for user customization. To acquire these parameters, a similar method to the one above is used: `kwargs.get("embedding_func", {})`.

--- a/gptcache/adapter/api.py
+++ b/gptcache/adapter/api.py
@@ -18,6 +18,7 @@ from gptcache.embedding import (
     Rwkv,
     PaddleNLP,
     UForm,
+    Nomic
 )
 from gptcache.embedding.base import BaseEmbedding
 from gptcache.manager import manager_factory
@@ -285,6 +286,8 @@ def _get_model(model_src, model_config=None):
         return PaddleNLP(**model_config)
     if model_src == "uform":
         return UForm(**model_config)
+    if model_src == "nomic":
+        return Nomic(**model_config)
 
 
 def _get_eval(strategy, kws=None):

--- a/gptcache/embedding/__init__.py
+++ b/gptcache/embedding/__init__.py
@@ -33,8 +33,8 @@ uform = LazyImport("uform", globals(), "gptcache.embedding.uform")
 nomic = LazyImport("nomic", globals(), "gptcache.embedding.nomic")
 
 
-def Nomic(model: str = "nomic-embed-text-v1.5", 
-          api_key: str = None, 
+def Nomic(model: str = "nomic-embed-text-v1.5",
+          api_key: str = None,
           task_type: str = "search_document",
           dimensionality: int = None):
     return nomic.Nomic(model, api_key, task_type, dimensionality)

--- a/gptcache/embedding/__init__.py
+++ b/gptcache/embedding/__init__.py
@@ -30,6 +30,14 @@ langchain = LazyImport("langchain", globals(), "gptcache.embedding.langchain")
 rwkv = LazyImport("rwkv", globals(), "gptcache.embedding.rwkv")
 paddlenlp = LazyImport("paddlenlp", globals(), "gptcache.embedding.paddlenlp")
 uform = LazyImport("uform", globals(), "gptcache.embedding.uform")
+nomic = LazyImport("nomic", globals(), "gptcache.embedding.nomic")
+
+
+def Nomic(model: str = "nomic-embed-text-v1.5", 
+          api_key: str = None, 
+          task_type: str = "search_document",
+          dimensionality: int = None):
+    return nomic.Nomic(model, api_key, task_type, dimensionality)
 
 
 def Cohere(model="large", api_key=None):

--- a/gptcache/embedding/nomic.py
+++ b/gptcache/embedding/nomic.py
@@ -1,3 +1,5 @@
+"""Nomic embedding integration"""
+
 import numpy as np
 
 from gptcache.utils import import_nomic
@@ -5,20 +7,17 @@ from gptcache.embedding.base import BaseEmbedding
 
 import_nomic()
 
-import nomic
-from nomic import embed
+import nomic # pylint: disable=C0413
+from nomic import embed # pylint: disable=C0413
 
 class Nomic(BaseEmbedding):
     """Generate text embedding for given text using Cohere.
-
     """
-
-    def __init__(self, 
+    def __init__(self,
                  model: str = "nomic-embed-text-v1.5",
                  api_key: str = None,
                  task_type: str = "search_document",
-                 dimensionality: int = None,
-                ) -> None:
+                 dimensionality: int = None) -> None:
         """Generate text embedding for given text using Nomic embed.
 
         :param model: model name, defaults to 'nomic-embed-text-v1.5'.
@@ -42,14 +41,13 @@ class Nomic(BaseEmbedding):
                             dimensionality=64)
             embed = encoder.to_embeddings(test_sentence)
         """
-        
         # Login to nomic
         nomic.cli.login(token=api_key)
 
         self._model = model
         self._task_type = task_type
         self._dimensionality = dimensionality
-        
+
     def to_embeddings(self, data, **_):
         """Generate embedding given text input
 
@@ -60,7 +58,7 @@ class Nomic(BaseEmbedding):
         """
         if not isinstance(data, list):
             data = [data]
-        
+
         # Response will be a dictionary with key 'embeddings'
         # and value will be a list of lists
         response = embed.text(
@@ -70,7 +68,7 @@ class Nomic(BaseEmbedding):
             dimensionality=self._dimensionality)
         embeddings = response['embeddings']
         return np.array(embeddings).astype("float32").squeeze(0)
-        
+
     @property
     def dimension(self):
         """Embedding dimension.
@@ -81,6 +79,4 @@ class Nomic(BaseEmbedding):
             foo_emb = self.to_embeddings("foo")
             self._dimensionality = len(foo_emb)
         return self._dimensionality
-
-
         

--- a/gptcache/embedding/nomic.py
+++ b/gptcache/embedding/nomic.py
@@ -67,7 +67,7 @@ class Nomic(BaseEmbedding):
             model=self._model,
             task_type=self._task_type,
             dimensionality=self._dimensionality)
-        embeddings = response['embeddings']
+        embeddings = response["embeddings"]
         return np.array(embeddings).astype("float32").squeeze(0)
 
     @property

--- a/gptcache/embedding/nomic.py
+++ b/gptcache/embedding/nomic.py
@@ -7,7 +7,8 @@ from gptcache.embedding.base import BaseEmbedding
 
 import_nomic()
 
-import nomic # pylint: disable=C0413
+# import nomic # pylint: disable=C0413
+from nomic import cli # pylint: disable=C0413
 from nomic import embed # pylint: disable=C0413
 
 class Nomic(BaseEmbedding):
@@ -36,13 +37,13 @@ class Nomic(BaseEmbedding):
             from gptcache.embedding import Nomic
 
             test_sentence = 'Hey this is Nomic embedding integration to gaptcache.'
-            encoder = Nomic(model='nomic-embed-text-v1.5', 
-                            api_key=os.getenv("NOMIC_API_KEY"), 
+            encoder = Nomic(model='nomic-embed-text-v1.5',
+                            api_key=os.getenv("NOMIC_API_KEY"),
                             dimensionality=64)
             embed = encoder.to_embeddings(test_sentence)
         """
         # Login to nomic
-        nomic.cli.login(token=api_key)
+        cli.login(token=api_key)
 
         self._model = model
         self._task_type = task_type

--- a/gptcache/embedding/nomic.py
+++ b/gptcache/embedding/nomic.py
@@ -80,4 +80,3 @@ class Nomic(BaseEmbedding):
             foo_emb = self.to_embeddings("foo")
             self._dimensionality = len(foo_emb)
         return self._dimensionality
-        

--- a/gptcache/embedding/nomic.py
+++ b/gptcache/embedding/nomic.py
@@ -1,0 +1,86 @@
+import numpy as np
+
+from gptcache.utils import import_nomic
+from gptcache.embedding.base import BaseEmbedding
+
+import_nomic()
+
+import nomic
+from nomic import embed
+
+class Nomic(BaseEmbedding):
+    """Generate text embedding for given text using Cohere.
+
+    """
+
+    def __init__(self, 
+                 model: str = "nomic-embed-text-v1.5",
+                 api_key: str = None,
+                 task_type: str = "search_document",
+                 dimensionality: int = None,
+                ) -> None:
+        """Generate text embedding for given text using Nomic embed.
+
+        :param model: model name, defaults to 'nomic-embed-text-v1.5'.
+        :type model: str
+        :param api_key: Nomic API Key.
+        :type api_key: str
+        :param task_type: Task type in Nomic, defaults to 'search_document'.
+        :type task_type: str
+        :param dimensionality: Desired dimension of embeddings.
+        :type dimensionality: int
+
+        Example:
+        .. code-block:: python
+
+            import os
+            from gptcache.embedding import Nomic
+
+            test_sentence = 'Hey this is Nomic embedding integration to gaptcache.'
+            encoder = Nomic(model='nomic-embed-text-v1.5', 
+                            api_key=os.getenv("NOMIC_API_KEY"), 
+                            dimensionality=64)
+            embed = encoder.to_embeddings(test_sentence)
+        """
+        
+        # Login to nomic
+        nomic.cli.login(token=api_key)
+
+        self._model = model
+        self._task_type = task_type
+        self._dimensionality = dimensionality
+        
+    def to_embeddings(self, data, **_):
+        """Generate embedding given text input
+
+        :param data: text in string.
+        :type data: str
+
+        :return: a text embedding in shape of (self._dimensionality,).
+        """
+        if not isinstance(data, list):
+            data = [data]
+        
+        # Response will be a dictionary with key 'embeddings'
+        # and value will be a list of lists
+        response = embed.text(
+            texts=data,
+            model=self._model,
+            task_type=self._task_type,
+            dimensionality=self._dimensionality)
+        embeddings = response['embeddings']
+        return np.array(embeddings).astype("float32").squeeze(0)
+        
+    @property
+    def dimension(self):
+        """Embedding dimension.
+
+        :return: embedding dimension
+        """
+        if not self._dimensionality:
+            foo_emb = self.to_embeddings("foo")
+            self._dimensionality = len(foo_emb)
+        return self._dimensionality
+
+
+        

--- a/gptcache/utils/__init__.py
+++ b/gptcache/utils/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "import_milvus_lite",
     "import_sbert",
     "import_cohere",
+    "import_nomic",
     "import_fasttext",
     "import_huggingface",
     "import_uform",
@@ -78,6 +79,10 @@ def import_sbert():
 
 def import_cohere():
     _check_library("cohere")
+
+
+def import_nomic():
+    _check_library("nomic")
 
 
 def import_fasttext():

--- a/tests/unit_tests/embedding/test_nomic.py
+++ b/tests/unit_tests/embedding/test_nomic.py
@@ -1,0 +1,17 @@
+import os
+import types
+from unittest.mock import patch
+from gptcache.utils import import_nomic
+from gptcache.embedding import Nomic
+from gptcache.adapter.api import _get_model
+
+import_nomic()
+
+def test_nomic():
+    t = Nomic(model='nomic-embed-text-v1.5', api_key=os.getenv("NOMIC_API_KEY"), dimensionality=64)
+    data = t.to_embeddings("foo")
+    assert len(data) == t.dimension, f"{len(data)}, {t.dimension}"
+
+    t = _get_model(model_src="nomic", model_config={"model": "nomic-embed-text-v1.5"})
+    data = t.to_embeddings("foo")
+    assert len(data) == t.dimension, f"{len(data)}, {t.dimension}"


### PR DESCRIPTION
This PR adds integration of [embeddings with Nomic](https://docs.nomic.ai/reference/python-api/embeddings).

**Example usage**:

```python
from gptcache.embedding import Nomic

test_sentence = 'Hey this is Nomic embedding integration to gptcache.'
encoder = Nomic(model='nomic-embed-text-v1.5', 
                            api_key='<your-nomic-api-key>', 
                            dimensionality=64)
embed = encoder.to_embeddings(test_sentence)
```

**Note**: I have tested this functionality and it works as intended.
Looking forward for review/feedback.