### PR TITLE
Fix readme encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Slash Your LLM API Costs by 10x 💰, Boost Speed by 100x ⚡
 
 📔 This project is undergoing swift development, and as such, the API may be subject to change at any time. For the most up-to-date information, please refer to the latest [documentation]( https://gptcache.readthedocs.io/en/latest/) and [release note](https://github.com/zilliztech/GPTCache/blob/main/docs/release_note.md).
 
+**NOTE:** As the number of large models is growing explosively and their API shape is constantly evolving, we no longer add support for new API or models. We encourage the usage of using the get and set API in gptcache, here is the demo code: https://github.com/zilliztech/GPTCache/blob/main/examples/adapter/api.py
+
 ## Quick Install
 
 `pip install gptcache`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,7 +102,7 @@ refer to the implementation of [milvus](https://github.com/zilliztech/GPTCache/b
 
 ## Add a new data manager
 
-refer to the implementation of [MapDataManager, SSDataManager](https://github.com/zilliztech/GPTCache/blob/main/gptcache/cache/data_manager.py).
+refer to the implementation of [MapDataManager, SSDataManager](https://github.com/zilliztech/GPTCache/blob/main/gptcache/manager/data_manager.py).
 
 1. Implement the [DataManager](https://github.com/zilliztech/GPTCache/blob/main/gptcache/manager/data_manager.py) interface
 2. Add the new store to the [get_data_manager](https://github.com/zilliztech/GPTCache/blob/main/gptcache/manager/data_manager.py) method

--- a/gptcache/__init__.py
+++ b/gptcache/__init__.py
@@ -1,5 +1,5 @@
 """gptcache version"""
-__version__ = "0.1.43"
+__version__ = "0.1.44"
 
 from gptcache.config import Config
 from gptcache.core import Cache

--- a/gptcache/manager/factory.py
+++ b/gptcache/manager/factory.py
@@ -118,6 +118,12 @@ def manager_factory(manager="map",
             maxmemory_samples=eviction_params.get("maxmemory_samples", scalar_params.get("maxmemory_samples")),
         )
 
+    if eviction_manager == "memory":
+        return get_data_manager(s, v, o, None,
+                                eviction_params.get("max_size", 1000),
+                                eviction_params.get("clean_size", None),
+                                eviction_params.get("eviction", "LRU"),)
+
     e = EvictionBase(
         name=eviction_manager,
         **eviction_params
@@ -194,7 +200,7 @@ def get_data_manager(
         vector_base = VectorBase(name=vector_base)
     if isinstance(object_base, str):
         object_base = ObjectBase(name=object_base)
-    if isinstance(eviction_base, str):
+    if isinstance(eviction_base, str) and eviction_base != "memory":
         eviction_base = EvictionBase(name=eviction_base)
     assert cache_base and vector_base
     return SSDataManager(cache_base, vector_base, object_base, eviction_base, max_size, clean_size, eviction)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 


### PR DESCRIPTION
Kind of silly, but on my windows PC I had to specify encoding="utf-8" for the readme to load correctly in setup.py. Python 3.12.5. I'm based on main, this might be fixed in dev.