### PR TITLE
Add W-TinyLFU eviction policy with cost-aware admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ The **Cache Manager** is responsible for controlling the operation of both the *
     - [x] Support FIFO eviction policy.
     - [x] Support LFU eviction policy.
     - [x] Support RR eviction policy.
-    - [ ] Support more complicated eviction policies.
+    - [x] Support W-TinyLFU eviction policy with cost-aware admission.
   - **Distributed Caching**
   
   If you were to scale your GPTCache deployment horizontally using in-memory caching, it won't be possible. Since the cached information would be limited to the single pod.

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@
     - [Start server](#start-server)
   - [Benchmark](#benchmark)
   - [How to use post-process function](#how-to-use-post-process-function)
+  - [How to set the eviction policy](#how-to-set-the-eviction-policy)
 
 ## How to run Visual Question Answering with MiniGPT-4
 
@@ -715,3 +716,29 @@ cache.init(
 ```
 
 See [processor/post_example.py](./processor/post_example.py) for a runnable example.
+
+## How to set the `eviction` policy
+
+GPTCache supports several eviction policies: LRU (default), FIFO, LFU, and W-TinyLFU.
+
+### W-TinyLFU eviction
+
+The W-TinyLFU policy combines a TinyLFU admission filter with a segmented LRU, achieving near-optimal hit rates. It optionally supports cost-aware admission for LLM workloads where response regeneration costs vary.
+
+See [eviction/wtinylfu_eviction.py](./eviction/wtinylfu_eviction.py) for full examples.
+
+```python
+from gptcache.manager import get_data_manager, CacheBase, VectorBase
+from gptcache.manager.eviction import EvictionBase
+
+data_manager = get_data_manager(
+    cache_base=CacheBase("sqlite"),
+    vector_base=VectorBase("faiss", dimension=onnx.dimension),
+    eviction_base=EvictionBase(
+        "wtinylfu",
+        maxsize=200,
+        clean_size=50,
+        cost_aware=True,      # weight admission by response token count
+    ),
+)
+```

--- a/examples/eviction/wtinylfu_eviction.py
+++ b/examples/eviction/wtinylfu_eviction.py
@@ -1,0 +1,92 @@
+from gptcache import Cache
+from gptcache.embedding import Onnx
+from gptcache.manager import get_data_manager, CacheBase, VectorBase
+from gptcache.manager.eviction import EvictionBase
+
+
+def wtinylfu_basic_example():
+    """
+    Basic W-TinyLFU eviction example.
+
+    Uses the default settings: 1% window, 20/80 probation/protected split,
+    cost-aware admission enabled. The policy combines frequency-based
+    admission filtering (TinyLFU) with cost-weighted eviction decisions,
+    preferring to retain expensive-to-regenerate cache entries.
+    """
+    onnx = Onnx()
+    data_manager = get_data_manager(
+        cache_base=CacheBase("sqlite"),
+        vector_base=VectorBase("faiss", dimension=onnx.dimension),
+        eviction_base=EvictionBase(
+            "wtinylfu",
+            maxsize=200,
+            clean_size=50,
+        ),
+    )
+
+    cache = Cache()
+    cache.init(data_manager=data_manager)
+    question = "What is github?"
+    answer = "Online platform for version control and code collaboration."
+    embedding = onnx.to_embeddings(question)
+    cache.import_data([question], [answer], [embedding])
+
+
+def wtinylfu_custom_params_example():
+    """
+    W-TinyLFU with custom parameters.
+
+    Tunable parameters:
+    - window_pct: window cache as % of total capacity (default: 1.0)
+    - probation_pct: probation segment as % of main cache (default: 20.0)
+    - cost_aware: enable cost-weighted admission (default: True)
+    - cms_width_multiplier: Count-Min Sketch width scaling (default: 1)
+    - reset_multiplier: CMS aging interval as multiple of capacity (default: 10)
+    """
+    onnx = Onnx()
+    data_manager = get_data_manager(
+        cache_base=CacheBase("sqlite"),
+        vector_base=VectorBase("faiss", dimension=onnx.dimension),
+        eviction_base=EvictionBase(
+            "wtinylfu",
+            maxsize=500,
+            clean_size=100,
+            window_pct=2.0,
+            probation_pct=25.0,
+            cost_aware=True,
+        ),
+    )
+
+    cache = Cache()
+    cache.init(data_manager=data_manager)
+    question = "Explain quantum computing"
+    answer = "Quantum computing uses quantum bits (qubits) that can exist in superposition..."
+    embedding = onnx.to_embeddings(question)
+    cache.import_data([question], [answer], [embedding])
+
+
+def wtinylfu_no_cost_example():
+    """
+    W-TinyLFU without cost awareness (pure frequency-based admission).
+
+    When cost_aware=False, the admission decision uses only the TinyLFU
+    frequency estimate, equivalent to Caffeine's default policy.
+    """
+    onnx = Onnx()
+    data_manager = get_data_manager(
+        cache_base=CacheBase("sqlite"),
+        vector_base=VectorBase("faiss", dimension=onnx.dimension),
+        eviction_base=EvictionBase(
+            "wtinylfu",
+            maxsize=200,
+            clean_size=50,
+            cost_aware=False,
+        ),
+    )
+
+    cache = Cache()
+    cache.init(data_manager=data_manager)
+    question = "What is machine learning?"
+    answer = "A subset of AI that enables systems to learn from data."
+    embedding = onnx.to_embeddings(question)
+    cache.import_data([question], [answer], [embedding])

--- a/gptcache/manager/eviction/count_min_sketch.py
+++ b/gptcache/manager/eviction/count_min_sketch.py
@@ -1,0 +1,113 @@
+"""4-bit packed Count-Min Sketch for frequency estimation.
+
+Uses the same design as Caffeine/Theine: 4 hash functions, 4-bit counters
+packed 16 per uint64 word, periodic halving for aging.
+"""
+
+import numpy as np
+
+
+def _next_power_of_2(n: int) -> int:
+    if n <= 0:
+        return 1
+    n -= 1
+    n |= n >> 1
+    n |= n >> 2
+    n |= n >> 4
+    n |= n >> 8
+    n |= n >> 16
+    n |= n >> 32
+    return n + 1
+
+
+def _rehash(h: int) -> int:
+    h = (h ^ (h >> 32)) & 0xFFFFFFFFFFFFFFFF
+    h = (h * 0x94D049BB133111EB) & 0xFFFFFFFFFFFFFFFF
+    h = (h ^ (h >> 32)) & 0xFFFFFFFFFFFFFFFF
+    return h
+
+
+_RESET_MASK = np.uint64(0x7777777777777777)
+_MAX_COUNT = 15
+
+
+class CountMinSketch:
+    """4-bit packed Count-Min Sketch with 4 hash functions.
+
+    Each counter is 4 bits (max value 15). 16 counters are packed into
+    one uint64 word. The sketch uses 4 independent hash functions derived
+    via iterative rehashing.
+
+    :param capacity: expected max number of tracked items (determines width)
+    :param width_multiplier: width = next_power_of_2(capacity * multiplier)
+    :param sample_size_multiplier: reset after this * capacity increments
+    """
+
+    def __init__(
+        self,
+        capacity: int,
+        width_multiplier: int = 1,
+        sample_size_multiplier: int = 10,
+    ):
+        self._width = _next_power_of_2(max(capacity * width_multiplier, 16))
+        self._mask = self._width - 1
+        # 4 rows, each row has width counters, packed 16 per uint64
+        words_per_row = max(self._width // 16, 1)
+        self._table = np.zeros(4 * words_per_row, dtype=np.uint64)
+        self._words_per_row = words_per_row
+        self._additions = 0
+        self._sample_size = max(capacity * sample_size_multiplier, 16)
+
+    def increment(self, key_hash: int) -> bool:
+        """Increment counters for the given hash. Returns True if any counter changed."""
+        h0 = _rehash(key_hash)
+        h1 = _rehash(h0)
+        h2 = _rehash(h1)
+        h3 = _rehash(h2)
+
+        added = self._inc_counter(0, h0 & self._mask)
+        added |= self._inc_counter(1, h1 & self._mask)
+        added |= self._inc_counter(2, h2 & self._mask)
+        added |= self._inc_counter(3, h3 & self._mask)
+
+        if added:
+            self._additions += 1
+
+        return added
+
+    def estimate(self, key_hash: int) -> int:
+        """Return the estimated frequency (minimum across all rows)."""
+        h0 = _rehash(key_hash)
+        h1 = _rehash(h0)
+        h2 = _rehash(h1)
+        h3 = _rehash(h2)
+
+        c0 = self._read_counter(0, h0 & self._mask)
+        c1 = self._read_counter(1, h1 & self._mask)
+        c2 = self._read_counter(2, h2 & self._mask)
+        c3 = self._read_counter(3, h3 & self._mask)
+
+        return min(c0, c1, c2, c3)
+
+    def reset(self):
+        """Halve all counters (aging / decay)."""
+        self._table = (self._table >> np.uint64(1)) & _RESET_MASK
+        self._additions = self._additions // 2
+
+    def _inc_counter(self, row: int, index: int) -> bool:
+        word_idx = row * self._words_per_row + index // 16
+        nibble_pos = np.uint64((index % 16) * 4)
+        current = int((self._table[word_idx] >> nibble_pos) & np.uint64(0xF))
+        if current < _MAX_COUNT:
+            self._table[word_idx] += np.uint64(1) << nibble_pos
+            return True
+        return False
+
+    def _read_counter(self, row: int, index: int) -> int:
+        word_idx = row * self._words_per_row + index // 16
+        nibble_pos = np.uint64((index % 16) * 4)
+        return int((self._table[word_idx] >> nibble_pos) & np.uint64(0xF))
+
+    @property
+    def additions(self) -> int:
+        return self._additions

--- a/gptcache/manager/eviction/doorkeeper.py
+++ b/gptcache/manager/eviction/doorkeeper.py
@@ -1,0 +1,66 @@
+"""Bloom filter doorkeeper for TinyLFU admission control.
+
+Filters out one-hit-wonders: only items seen at least twice get their
+Count-Min Sketch counters incremented. This prevents long-tail pollution.
+"""
+
+import math
+
+import numpy as np
+
+
+class Doorkeeper:
+    """Simple Bloom filter that tracks whether an item has been seen before.
+
+    :param capacity: expected number of insertions before reset
+    :param fp_rate: target false positive rate (default 1%)
+    """
+
+    def __init__(self, capacity: int = 10000, fp_rate: float = 0.01):
+        # Optimal sizing: m = -n*ln(p) / (ln2)^2, k = (m/n)*ln2
+        if capacity <= 0:
+            capacity = 16
+        m = int(-capacity * math.log(fp_rate) / (math.log(2) ** 2))
+        m = max(m, 64)
+        self._num_bits = m
+        self._num_hashes = max(int((m / capacity) * math.log(2)), 1)
+        # Bit array stored as uint64 words
+        self._words = np.zeros((m + 63) // 64, dtype=np.uint64)
+
+    def allow(self, key_hash: int) -> bool:
+        """Check if key was seen before, then add it.
+
+        Returns True if the key was already present (second+ access).
+        Always adds the key regardless.
+        """
+        already_present = self.contains(key_hash)
+        self.add(key_hash)
+        return already_present
+
+    def contains(self, key_hash: int) -> bool:
+        """Check membership without modifying the filter."""
+        for i in range(self._num_hashes):
+            bit_pos = self._hash_pos(key_hash, i)
+            word_idx = bit_pos >> 6  # bit_pos // 64
+            bit_idx = np.uint64(bit_pos & 63)
+            if not (self._words[word_idx] & (np.uint64(1) << bit_idx)):
+                return False
+        return True
+
+    def add(self, key_hash: int):
+        """Add a key to the filter."""
+        for i in range(self._num_hashes):
+            bit_pos = self._hash_pos(key_hash, i)
+            word_idx = bit_pos >> 6
+            bit_idx = np.uint64(bit_pos & 63)
+            self._words[word_idx] |= np.uint64(1) << bit_idx
+
+    def clear(self):
+        """Reset the filter (remove all entries)."""
+        self._words[:] = np.uint64(0)
+
+    def _hash_pos(self, key_hash: int, i: int) -> int:
+        # Double hashing: h(i) = (h1 + i*h2) mod m
+        h1 = key_hash & 0xFFFFFFFF
+        h2 = (key_hash >> 32) & 0xFFFFFFFF
+        return ((h1 + i * h2) & 0xFFFFFFFFFFFFFFFF) % self._num_bits

--- a/gptcache/manager/eviction/manager.py
+++ b/gptcache/manager/eviction/manager.py
@@ -43,6 +43,11 @@ class EvictionBase:
             from gptcache.manager.eviction.distributed_cache import NoOpEviction
             eviction_base = NoOpEviction()
             return eviction_base
+        if name == "wtinylfu":
+            from gptcache.manager.eviction.wtinylfu_eviction import WTinyLFUEviction
+            eviction_base = WTinyLFUEviction(
+                maxsize=maxsize, clean_size=clean_size, on_evict=on_evict, **kwargs
+            )
+            return eviction_base
 
-        else:
-            raise NotFoundError("eviction base", name)
+        raise NotFoundError("eviction base", name)

--- a/gptcache/manager/eviction/segmented_lru.py
+++ b/gptcache/manager/eviction/segmented_lru.py
@@ -1,0 +1,99 @@
+"""Segmented LRU (SLRU) cache with probation and protected segments.
+
+New items enter probation. On a hit in probation, items are promoted to
+protected. When protected overflows, its LRU victim is demoted back to
+probation. Eviction victims are always taken from probation's LRU end.
+"""
+
+from collections import OrderedDict
+from typing import Any, Optional, Tuple
+
+
+class SegmentedLRU:
+    """Two-segment LRU: probation (trial) + protected (proven).
+
+    :param probation_capacity: max entries in probation segment
+    :param protected_capacity: max entries in protected segment
+    """
+
+    def __init__(self, probation_capacity: int, protected_capacity: int):
+        self._probation = OrderedDict()  # LRU: first item = least recent
+        self._protected = OrderedDict()
+        self._probation_cap = max(probation_capacity, 1)
+        self._protected_cap = max(protected_capacity, 1)
+
+    def get(self, key: Any) -> Optional[Any]:
+        """Access a key, triggering promotion if in probation.
+
+        Returns the value or None if not found.
+        """
+        # Hit in protected: refresh LRU position
+        if key in self._protected:
+            self._protected.move_to_end(key)
+            return self._protected[key]
+
+        # Hit in probation: promote to protected
+        if key in self._probation:
+            value = self._probation.pop(key)
+            self._protected[key] = value
+            self._protected.move_to_end(key)
+            # If protected overflows, demote its LRU to probation
+            self._handle_protected_overflow()
+            return value
+
+        return None
+
+    def put(self, key: Any, value: Any = True):
+        """Insert into probation segment (for newly admitted items)."""
+        if key in self._protected:
+            self._protected.move_to_end(key)
+            self._protected[key] = value
+            return
+        if key in self._probation:
+            self._probation.move_to_end(key)
+            self._probation[key] = value
+            return
+        self._probation[key] = value
+        self._probation.move_to_end(key)
+
+    def peek_victim(self) -> Optional[Any]:
+        """Peek at the probation LRU victim without removing it."""
+        if not self._probation:
+            return None
+        return next(iter(self._probation))
+
+    def evict(self) -> Optional[Tuple[Any, Any]]:
+        """Remove and return the probation LRU victim as (key, value)."""
+        if not self._probation:
+            return None
+        return self._probation.popitem(last=False)
+
+    def remove(self, key: Any) -> bool:
+        """Remove a key from either segment. Returns True if found."""
+        if key in self._protected:
+            del self._protected[key]
+            return True
+        if key in self._probation:
+            del self._probation[key]
+            return True
+        return False
+
+    def __contains__(self, key: Any) -> bool:
+        return key in self._protected or key in self._probation
+
+    def __len__(self) -> int:
+        return len(self._protected) + len(self._probation)
+
+    @property
+    def probation_size(self) -> int:
+        return len(self._probation)
+
+    @property
+    def protected_size(self) -> int:
+        return len(self._protected)
+
+    def _handle_protected_overflow(self):
+        while len(self._protected) > self._protected_cap:
+            demoted_key, demoted_val = self._protected.popitem(last=False)
+            self._probation[demoted_key] = demoted_val
+            self._probation.move_to_end(demoted_key)

--- a/gptcache/manager/eviction/wtinylfu_eviction.py
+++ b/gptcache/manager/eviction/wtinylfu_eviction.py
@@ -1,0 +1,222 @@
+"""Token-Cost-Aware W-TinyLFU eviction policy for GPTCache.
+
+Combines a frequency-based admission filter (TinyLFU with Count-Min Sketch
+and Bloom filter doorkeeper) with a segmented LRU main cache and an LRU
+window cache. Optionally weighs eviction decisions by the regeneration cost
+of cached entries (e.g., response token count).
+
+Architecture:
+    Window LRU (1%) --evict--> TinyLFU admission gate --admit--> Main SLRU (99%)
+                                     |                              |
+                              Count-Min Sketch              Probation (20%)
+                              + Bloom doorkeeper            Protected (80%)
+
+References:
+    - TinyLFU: Gil Einziger, Roy Friedman, Ben Manes (arXiv:1512.00727)
+    - Caffeine: github.com/ben-manes/caffeine
+    - Theine: github.com/Yiling-J/theine
+"""
+
+import random
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional
+
+from gptcache.manager.eviction.base import EvictionBase as EvictionBaseABC
+from gptcache.manager.eviction.count_min_sketch import CountMinSketch
+from gptcache.manager.eviction.doorkeeper import Doorkeeper
+from gptcache.manager.eviction.segmented_lru import SegmentedLRU
+
+
+class WTinyLFUEviction(EvictionBaseABC):
+    """W-TinyLFU eviction policy with optional cost-awareness.
+
+    :param maxsize: total cache capacity (entry count)
+    :param clean_size: number of entries to evict per batch (default 20% of maxsize)
+    :param on_evict: callback receiving list of evicted entry IDs
+    :param window_pct: window cache as percentage of total capacity (default 1.0)
+    :param probation_pct: probation as percentage of main cache (default 20.0)
+    :param cost_aware: enable cost-weighted eviction decisions (default True)
+    :param cms_width_multiplier: CMS width = next_power_of_2(maxsize * this)
+    :param reset_multiplier: CMS resets every maxsize * this increments
+    """
+
+    def __init__(
+        self,
+        maxsize: int = 1000,
+        clean_size: int = 0,
+        on_evict: Optional[Callable[[List[Any]], None]] = None,
+        window_pct: float = 1.0,
+        probation_pct: float = 20.0,
+        cost_aware: bool = True,
+        cms_width_multiplier: int = 1,
+        reset_multiplier: int = 10,
+        **kwargs,
+    ):
+        self._maxsize = max(maxsize, 4)
+        self._clean_size = clean_size if clean_size else int(self._maxsize * 0.2)
+        self._on_evict = on_evict
+        self._cost_aware = cost_aware
+
+        # Segment sizes — ensure minimum viable sizes for small caches
+        # Caffeine uses 1% window, but at small sizes we need at least 1 slot
+        # per segment. For cache_size < 20, use larger percentages.
+        window_size = max(int(self._maxsize * window_pct / 100.0), 1)
+        main_size = max(self._maxsize - window_size, 2)
+        probation_size = max(int(main_size * probation_pct / 100.0), 1)
+        protected_size = max(main_size - probation_size, 1)
+        # Recalculate total to match
+        self._maxsize = window_size + probation_size + protected_size
+
+        # Data structures
+        self._window = OrderedDict()  # LRU window cache
+        self._window_cap = window_size
+        self._main = SegmentedLRU(probation_size, protected_size)
+        self._sketch = CountMinSketch(
+            self._maxsize,
+            width_multiplier=cms_width_multiplier,
+            sample_size_multiplier=reset_multiplier,
+        )
+        self._doorkeeper = Doorkeeper(
+            capacity=self._maxsize * reset_multiplier
+        )
+
+        # Cost metadata: entry_id -> cost weight
+        self._cost_map: Dict[int, float] = {}
+        # Track which segment each key is in for fast lookup
+        self._key_location: Dict[Any, str] = {}  # key -> "window" | "main"
+
+    def put(self, objs: List[Any]):
+        """Register entry IDs after insertion into scalar/vector stores.
+
+        Triggers eviction via the W-TinyLFU admission pipeline when the
+        cache is full.
+        """
+        evicted = []
+
+        for obj in objs:
+            # If already tracked, just touch it
+            if obj in self._key_location:
+                self.get(obj)
+                continue
+
+            key_hash = hash(obj)
+            self._increment_sketch(key_hash)
+
+            # Insert into window cache
+            self._window[obj] = True
+            self._window.move_to_end(obj)
+            self._key_location[obj] = "window"
+
+            # If window overflows, run admission
+            while len(self._window) > self._window_cap:
+                # Evict LRU from window -> becomes candidate
+                cand_key, _ = self._window.popitem(last=False)
+                del self._key_location[cand_key]
+
+                if len(self._main) < (self._maxsize - self._window_cap):
+                    # Main has room: admit unconditionally
+                    self._main.put(cand_key, True)
+                    self._key_location[cand_key] = "main"
+                else:
+                    # Main full: candidate competes with probation victim
+                    victim_key = self._main.peek_victim()
+                    if victim_key is not None and self._admit(cand_key, victim_key):
+                        self._main.evict()
+                        del self._key_location[victim_key]
+                        self._cost_map.pop(victim_key, None)
+                        evicted.append(victim_key)
+                        # Admit candidate
+                        self._main.put(cand_key, True)
+                        self._key_location[cand_key] = "main"
+                    else:
+                        # Candidate loses, discard it
+                        self._cost_map.pop(cand_key, None)
+                        evicted.append(cand_key)
+
+        if evicted and self._on_evict:
+            self._on_evict(evicted)
+
+    def get(self, obj: Any):
+        """Touch an entry on cache hit, updating frequency and LRU position."""
+        key_hash = hash(obj)
+        self._increment_sketch(key_hash)
+
+        loc = self._key_location.get(obj)
+        if loc == "window":
+            if obj in self._window:
+                self._window.move_to_end(obj)
+                return True
+        elif loc == "main":
+            result = self._main.get(obj)
+            if result is not None:
+                return result
+
+        return None
+
+    @property
+    def policy(self) -> str:
+        return "WTINYLFU"
+
+    def set_cost(self, obj_id: Any, cost: float):
+        """Set the regeneration cost for a cache entry.
+
+        Cost is used in admission decisions when cost_aware=True.
+        Higher cost = more valuable to keep cached.
+        """
+        self._cost_map[obj_id] = cost
+
+    def _increment_sketch(self, key_hash: int):
+        """Doorkeeper-gated sketch increment."""
+        if self._doorkeeper.allow(key_hash):
+            self._sketch.increment(key_hash)
+        if self._sketch.additions >= self._sketch._sample_size:
+            self._sketch.reset()
+            self._doorkeeper.clear()
+
+    def _estimate_frequency(self, key: Any) -> int:
+        """Estimate access frequency for a key."""
+        key_hash = hash(key)
+        if self._doorkeeper.contains(key_hash):
+            return self._sketch.estimate(key_hash) + 1
+        return 0
+
+    def _get_cost(self, key: Any) -> float:
+        """Get the cost weight for a key (default 1.0)."""
+        if not self._cost_aware:
+            return 1.0
+        return self._cost_map.get(key, 1.0)
+
+    _ADMIT_HASHDOS_THRESHOLD = 6
+
+    def _admit(self, candidate_key: Any, victim_key: Any) -> bool:
+        """W-TinyLFU admission decision: should candidate replace victim?
+
+        Follows Caffeine's admission policy:
+        1. Candidate wins if its estimated value exceeds the victim's.
+        2. When cost-aware, value = frequency * cost; otherwise value = frequency.
+        3. At high candidate frequencies (>= 6), admit with ~1/128 probability
+           as a hash-DoS defence (Caffeine's ADMIT_HASHDOS_THRESHOLD).
+        4. Otherwise reject — favour cache stability at low frequencies.
+        """
+        freq_c = self._estimate_frequency(candidate_key)
+        freq_v = self._estimate_frequency(victim_key)
+
+        if self._cost_aware:
+            cost_c = self._get_cost(candidate_key)
+            cost_v = self._get_cost(victim_key)
+            value_c = freq_c * cost_c
+            value_v = freq_v * cost_v
+        else:
+            value_c = freq_c
+            value_v = freq_v
+
+        if value_c > value_v:
+            return True
+
+        # Hash-DoS defence: at high frequencies, admit with small probability
+        # to prevent an attacker from pinning entries. Matches Caffeine's
+        # ~1/128 random admission when candidateFreq >= 6.
+        if freq_c >= self._ADMIT_HASHDOS_THRESHOLD:
+            return random.randint(0, 127) == 0
+
+        return False

--- a/tests/unit_tests/eviction/test_count_min_sketch.py
+++ b/tests/unit_tests/eviction/test_count_min_sketch.py
@@ -1,0 +1,61 @@
+import unittest
+
+from gptcache.manager.eviction.count_min_sketch import CountMinSketch
+
+
+class TestCountMinSketch(unittest.TestCase):
+
+    def test_increment_and_estimate(self):
+        cms = CountMinSketch(capacity=100)
+        for _ in range(5):
+            cms.increment(42)
+        self.assertEqual(cms.estimate(42), 5)
+
+    def test_estimate_returns_minimum(self):
+        """Estimate should be the min across all 4 rows (no overcount for the key itself)."""
+        cms = CountMinSketch(capacity=1000)
+        for _ in range(10):
+            cms.increment(100)
+        est = cms.estimate(100)
+        self.assertEqual(est, 10)
+
+    def test_unseen_key_returns_zero(self):
+        cms = CountMinSketch(capacity=100)
+        cms.increment(1)
+        self.assertEqual(cms.estimate(999), 0)
+
+    def test_counter_cap_at_15(self):
+        cms = CountMinSketch(capacity=100, sample_size_multiplier=10000)
+        for _ in range(50):
+            cms.increment(7)
+        self.assertLessEqual(cms.estimate(7), 15)
+
+    def test_reset_halves_counters(self):
+        cms = CountMinSketch(capacity=100, sample_size_multiplier=10000)
+        for _ in range(10):
+            cms.increment(55)
+        before = cms.estimate(55)
+        cms.reset()
+        after = cms.estimate(55)
+        self.assertEqual(after, before // 2)
+
+    def test_additions_tracked(self):
+        """CMS tracks additions so the caller can decide when to reset."""
+        capacity = 16
+        cms = CountMinSketch(capacity=capacity, sample_size_multiplier=2)
+        for i in range(10):
+            cms.increment(i)
+        self.assertEqual(cms.additions, 10)
+        self.assertEqual(cms._sample_size, capacity * 2)
+
+    def test_multiple_keys(self):
+        cms = CountMinSketch(capacity=1000)
+        for _ in range(8):
+            cms.increment(1)
+        for _ in range(3):
+            cms.increment(2)
+        self.assertGreater(cms.estimate(1), cms.estimate(2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/eviction/test_doorkeeper.py
+++ b/tests/unit_tests/eviction/test_doorkeeper.py
@@ -1,0 +1,52 @@
+import unittest
+
+from gptcache.manager.eviction.doorkeeper import Doorkeeper
+
+
+class TestDoorkeeper(unittest.TestCase):
+
+    def test_first_access_rejected(self):
+        dk = Doorkeeper(capacity=1000)
+        self.assertFalse(dk.allow(42))
+
+    def test_second_access_allowed(self):
+        dk = Doorkeeper(capacity=1000)
+        dk.allow(42)  # first access
+        self.assertTrue(dk.allow(42))  # second access
+
+    def test_contains_without_add(self):
+        dk = Doorkeeper(capacity=1000)
+        self.assertFalse(dk.contains(99))
+        dk.add(99)
+        self.assertTrue(dk.contains(99))
+
+    def test_clear_resets(self):
+        dk = Doorkeeper(capacity=1000)
+        dk.add(42)
+        dk.add(99)
+        dk.clear()
+        self.assertFalse(dk.contains(42))
+        self.assertFalse(dk.contains(99))
+
+    def test_false_positive_rate(self):
+        dk = Doorkeeper(capacity=10000, fp_rate=0.01)
+        # Insert 5000 items
+        for i in range(5000):
+            dk.add(i)
+        # Check 5000 items that were NOT inserted
+        false_positives = sum(1 for i in range(5000, 10000) if dk.contains(i))
+        fp_rate = false_positives / 5000
+        # Allow some slack: target is 1%, accept up to 3%
+        self.assertLess(fp_rate, 0.03, f"FP rate {fp_rate:.3f} too high")
+
+    def test_many_distinct_keys(self):
+        dk = Doorkeeper(capacity=100)
+        for i in range(100):
+            dk.add(i)
+        # All inserted keys should be found
+        for i in range(100):
+            self.assertTrue(dk.contains(i))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/eviction/test_segmented_lru.py
+++ b/tests/unit_tests/eviction/test_segmented_lru.py
@@ -1,0 +1,88 @@
+import unittest
+
+from gptcache.manager.eviction.segmented_lru import SegmentedLRU
+
+
+class TestSegmentedLRU(unittest.TestCase):
+
+    def test_insert_into_probation(self):
+        slru = SegmentedLRU(probation_capacity=5, protected_capacity=10)
+        slru.put("a", 1)
+        slru.put("b", 2)
+        self.assertEqual(slru.probation_size, 2)
+        self.assertEqual(slru.protected_size, 0)
+
+    def test_promote_on_hit(self):
+        slru = SegmentedLRU(probation_capacity=5, protected_capacity=10)
+        slru.put("a", 1)
+        self.assertEqual(slru.probation_size, 1)
+        # Hit in probation -> promote to protected
+        slru.get("a")
+        self.assertEqual(slru.probation_size, 0)
+        self.assertEqual(slru.protected_size, 1)
+
+    def test_demote_on_protected_overflow(self):
+        slru = SegmentedLRU(probation_capacity=5, protected_capacity=2)
+        # Fill probation with 3 items and promote all to protected
+        slru.put("a")
+        slru.put("b")
+        slru.put("c")
+        slru.get("a")  # promote a
+        slru.get("b")  # promote b
+        slru.get("c")  # promote c -> protected overflows, "a" demoted
+        self.assertEqual(slru.protected_size, 2)
+        # "a" was demoted back to probation
+        self.assertIn("a", slru)
+        self.assertEqual(len(slru), 3)
+
+    def test_evict_from_probation(self):
+        slru = SegmentedLRU(probation_capacity=3, protected_capacity=5)
+        slru.put("a")
+        slru.put("b")
+        slru.put("c")
+        victim = slru.evict()
+        self.assertEqual(victim[0], "a")  # LRU item
+        self.assertEqual(len(slru), 2)
+
+    def test_peek_victim(self):
+        slru = SegmentedLRU(probation_capacity=3, protected_capacity=5)
+        slru.put("x")
+        slru.put("y")
+        victim = slru.peek_victim()
+        self.assertEqual(victim, "x")
+        self.assertEqual(len(slru), 2)  # peek doesn't remove
+
+    def test_remove(self):
+        slru = SegmentedLRU(probation_capacity=5, protected_capacity=5)
+        slru.put("a")
+        slru.get("a")  # promote to protected
+        slru.put("b")  # in probation
+        self.assertTrue(slru.remove("a"))
+        self.assertTrue(slru.remove("b"))
+        self.assertEqual(len(slru), 0)
+
+    def test_contains(self):
+        slru = SegmentedLRU(probation_capacity=5, protected_capacity=5)
+        slru.put("a")
+        self.assertIn("a", slru)
+        self.assertNotIn("b", slru)
+
+    def test_get_miss_returns_none(self):
+        slru = SegmentedLRU(probation_capacity=5, protected_capacity=5)
+        self.assertIsNone(slru.get("nonexistent"))
+
+    def test_protected_hit_refreshes(self):
+        slru = SegmentedLRU(probation_capacity=5, protected_capacity=3)
+        slru.put("a")
+        slru.put("b")
+        slru.put("c")
+        slru.get("a")  # promote
+        slru.get("b")  # promote
+        slru.get("c")  # promote -> "a" demoted
+        # Now access "b" in protected to refresh it
+        slru.get("b")
+        # "b" should be MRU in protected, safe from demotion
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/eviction/test_wtinylfu.py
+++ b/tests/unit_tests/eviction/test_wtinylfu.py
@@ -1,0 +1,198 @@
+import unittest
+
+from gptcache.manager.eviction.manager import EvictionBase
+
+
+class TestWTinyLFU(unittest.TestCase):
+
+    def test_basic_put_get(self):
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=10, on_evict=lambda x: None
+        )
+        eviction.put([1, 2, 3])
+        self.assertIsNotNone(eviction.get(1))
+        self.assertIsNotNone(eviction.get(2))
+        self.assertIsNotNone(eviction.get(3))
+
+    def test_policy_property(self):
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=10, on_evict=lambda x: None
+        )
+        self.assertEqual(eviction.policy, "WTINYLFU")
+
+    def test_eviction_triggered(self):
+        evicted = []
+
+        def on_evict(keys):
+            evicted.extend(keys)
+
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=5, clean_size=1, on_evict=on_evict
+        )
+        # Insert more than maxsize
+        for i in range(10):
+            eviction.put([i])
+        # Some items should have been evicted
+        self.assertGreater(len(evicted), 0)
+
+    def test_frequent_items_retained(self):
+        evicted = []
+
+        def on_evict(keys):
+            evicted.extend(keys)
+
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=10, clean_size=1, on_evict=on_evict
+        )
+
+        # Insert items 0-9
+        eviction.put(list(range(10)))
+
+        # Access items 0-4 many times to boost their frequency
+        for _ in range(20):
+            for i in range(5):
+                eviction.get(i)
+
+        # Now insert items 10-19, forcing eviction
+        for i in range(10, 20):
+            eviction.put([i])
+
+        # Items 0-4 should mostly survive due to high frequency
+        surviving_popular = sum(1 for i in range(5) if i not in evicted)
+        self.assertGreaterEqual(surviving_popular, 3)
+
+    def test_cost_aware_retention(self):
+        evicted = []
+
+        def on_evict(keys):
+            evicted.extend(keys)
+
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=10, clean_size=1,
+            on_evict=on_evict, cost_aware=True
+        )
+
+        # Insert items 0-9
+        eviction.put(list(range(10)))
+
+        # Set high cost for items 0-4 (expensive to regenerate)
+        for i in range(5):
+            eviction.set_cost(i, 1000.0)
+        # Set low cost for items 5-9
+        for i in range(5, 10):
+            eviction.set_cost(i, 1.0)
+
+        # Access all items equally
+        for _ in range(5):
+            for i in range(10):
+                eviction.get(i)
+
+        # Now insert items 10-19, forcing eviction
+        for i in range(10, 20):
+            eviction.set_cost(i, 1.0)
+            eviction.put([i])
+
+        # High-cost items (0-4) should be preferentially retained
+        high_cost_evicted = sum(1 for i in range(5) if i in evicted)
+        low_cost_evicted = sum(1 for i in range(5, 10) if i in evicted)
+        self.assertLessEqual(high_cost_evicted, low_cost_evicted)
+
+    def test_one_hit_wonders_evicted(self):
+        evicted = []
+
+        def on_evict(keys):
+            evicted.extend(keys)
+
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=10, clean_size=1, on_evict=on_evict
+        )
+
+        # Insert items 0-4 and access them heavily
+        eviction.put(list(range(5)))
+        for _ in range(20):
+            for i in range(5):
+                eviction.get(i)
+
+        # Insert items 5-9 (no re-access -> one-hit wonders)
+        eviction.put(list(range(5, 10)))
+
+        # Insert items 10-14, forcing eviction
+        for i in range(10, 15):
+            eviction.put([i])
+
+        # One-hit wonders (5-9) should be evicted before frequent items (0-4)
+        frequent_evicted = sum(1 for i in range(5) if i in evicted)
+        one_hit_evicted = sum(1 for i in range(5, 10) if i in evicted)
+        self.assertLessEqual(frequent_evicted, one_hit_evicted)
+
+    def test_clean_size_default(self):
+        """Default clean_size should be 20% of maxsize."""
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=100, on_evict=lambda x: None
+        )
+        self.assertEqual(eviction._clean_size, 20)
+
+    def test_set_cost(self):
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=10, on_evict=lambda x: None
+        )
+        eviction.put([1])
+        eviction.set_cost(1, 500.0)
+        self.assertEqual(eviction._cost_map[1], 500.0)
+
+    def test_doorkeeper_cleared_on_sketch_reset(self):
+        """Per the TinyLFU paper, the doorkeeper must be cleared when the
+        CMS counters are halved to prevent stale false positives."""
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=100, on_evict=lambda x: None,
+            reset_multiplier=1,  # sample_size = 100
+        )
+        # Plant a sentinel in the doorkeeper before any resets
+        sentinel = hash(0xDEADBEEF)
+        eviction._doorkeeper.add(sentinel)
+        self.assertTrue(eviction._doorkeeper.contains(sentinel))
+
+        # Drive sketch increments past sample_size to trigger reset+clear.
+        # put() seeds the doorkeeper; subsequent get() calls pass through
+        # and increment the sketch.  100 items × 5 rounds > sample_size.
+        eviction.put(list(range(50)))
+        for _ in range(5):
+            for i in range(50):
+                eviction.get(i)
+
+        # The sentinel was planted before any reset.  After clear it must
+        # be gone (bloom filter has ~958 bits with ≤50 items → FP < 0.01%).
+        self.assertFalse(eviction._doorkeeper.contains(sentinel),
+                         "Doorkeeper should be cleared when CMS resets")
+
+    def test_matches_existing_test_pattern_lru_style(self):
+        """Mirrors the existing test_lru pattern to verify compatibility."""
+        datas = []
+
+        def on_evict(deletes):
+            for delete in deletes:
+                if delete in datas:
+                    datas.remove(delete)
+
+        eviction = EvictionBase.get(
+            name="wtinylfu", maxsize=4, clean_size=2, on_evict=on_evict
+        )
+
+        def add_data(data):
+            datas.append(data)
+            eviction.put([data])
+
+        add_data(1)
+        add_data(2)
+        add_data(3)
+        add_data(4)
+        # Access item 1 many times to boost frequency
+        for _ in range(10):
+            eviction.get(1)
+        add_data(5)
+        # After eviction, item 1 should survive (highest frequency)
+        self.assertIn(1, datas)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a **W-TinyLFU eviction policy** (`name="wtinylfu"`) that combines frequency-based admission filtering with optional cost-weighted eviction, targeting LLM caching workloads where response regeneration costs vary by orders of magnitude.

This addresses the roadmap item: _"Support more complicated eviction policies"_.

### Architecture (following Caffeine's design)

- **Window LRU** (1% capacity): absorbs burst/recency traffic
- **TinyLFU admission gate**: 4-bit Count-Min Sketch + Bloom filter doorkeeper rejects one-hit-wonders
- **Segmented main LRU** (99%): probation (20%) + protected (80%) with promotion on hit

### Cost-aware extension

When `cost_aware=True` (default), the admission decision multiplies each candidate's frequency estimate by its response token count (`set_cost()` API), biasing eviction toward retaining expensive entries. This is an additive extension — the existing `put`/`get`/`policy` interface is unchanged.

### Files changed

| File | Lines | Description |
|---|---|---|
| `gptcache/manager/eviction/wtinylfu_eviction.py` | 222 | Main policy (extends `EvictionBase`) |
| `gptcache/manager/eviction/count_min_sketch.py` | 113 | 4-bit packed CMS with periodic aging |
| `gptcache/manager/eviction/doorkeeper.py` | 66 | Bloom filter for one-hit-wonder rejection |
| `gptcache/manager/eviction/segmented_lru.py` | 99 | Two-tier LRU with promotion/demotion |
| `gptcache/manager/eviction/manager.py` | +7 | Factory registration |
| `tests/unit_tests/eviction/test_*.py` | 4 files | 32 unit tests |
| `examples/eviction/wtinylfu_eviction.py` | 92 | Usage examples |
| `examples/README.md` | +27 | Eviction section added |
| `README.md` | +1 | Updated roadmap checklist |

### Usage

```python
from gptcache.manager import get_data_manager, CacheBase, VectorBase
from gptcache.manager.eviction import EvictionBase

data_manager = get_data_manager(
    cache_base=CacheBase("sqlite"),
    vector_base=VectorBase("faiss", dimension=onnx.dimension),
    eviction_base=EvictionBase(
        "wtinylfu",
        maxsize=200,
        clean_size=50,
        cost_aware=True,       # enable token-cost weighting
        window_pct=1.0,        # window cache % (default: 1%)
        probation_pct=20.0,    # probation segment % of main (default: 20%)
    ),
)
```

### Design decisions

- **No new dependencies**: uses only `numpy` (already in requirements) + stdlib
- **Backward compatible**: adds a new factory path without modifying existing policies
- **Configurable**: all major parameters exposed with paper-recommended defaults
- **Hash-DoS defense**: at frequency >= 6, admits with ~1/128 probability (matches Caffeine)

### Benchmark results

Full benchmarks (synthetic Zipfian + LMSYS-Chat-1M real data, 3 trials each) are available in the [deliverables folder(not part of the commit to reduce noise)](https://github.com/a1amit/GPTCache/tree/feature/wtinylfu-cost-aware/deliverables) ([figures](https://github.com/a1amit/GPTCache/tree/feature/wtinylfu-cost-aware/deliverables/figures_synthetic), [raw JSON results](https://github.com/a1amit/GPTCache/tree/feature/wtinylfu-cost-aware/deliverables/results_synthetic)). Key results vs. LRU baseline: +74% token savings on synthetic Zipfian workload (cs=50), +94% on real LMSYS-Chat-1M conversations (cs=50, threshold=0.80).

### References

- Einziger, Friedman, Manes. [TinyLFU: A Highly Efficient Cache Admission Policy](https://doi.org/10.1145/3149371). ACM Trans. Storage, 2017. ([arXiv](https://arxiv.org/abs/1512.00727))
- [Caffeine](https://github.com/ben-manes/caffeine) (Java) — reference implementation
- [Theine](https://github.com/Yiling-J/theine) (Python) — design reference

## Test plan

- [x] 32 new unit tests passing (`pytest tests/unit_tests/eviction/ -v`)
- [x] All 38 eviction tests passing (32 new + 6 existing)
- [x] Usage examples added to `examples/eviction/`
- [x] `examples/README.md` updated
- [x] Root `README.md` roadmap updated

> **Note**: Targeting `main` since `dev` has not been updated since September 2024 and recent PRs (#668, #669) merge directly to `main`.
